### PR TITLE
Fix: Ensure TooltipTrigger receives a single child

### DIFF
--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -40,7 +40,7 @@ export function Tooltip({
   return (
     <TooltipProvider>
       <TooltipRoot delayDuration={delayDuration}>
-        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipTrigger asChild><span>{children}</span></TooltipTrigger>
         <TooltipContent side={side}>{content}</TooltipContent>
       </TooltipRoot>
     </TooltipProvider>


### PR DESCRIPTION
The `TooltipTrigger` component in `src/components/ui/tooltip.tsx` was throwing a "React.Children.only expected to receive a single React element child" error. This occurred because the `asChild` prop requires a single React element child, but the `children` prop being passed could sometimes resolve to multiple elements or a fragment.

This commit wraps the `children` prop within a `<span>` inside the `TooltipTrigger`. This ensures that `TooltipTrigger` always receives a single, valid HTML element as its child, satisfying the requirement of the `asChild` prop and resolving the error.

This change allows the tooltip to function correctly, particularly in scenarios like the Sidebar where a Next.js Link component is passed as a child to the Tooltip.