### PR TITLE
Refactor: Improve sign-out process and address navigation

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -19,13 +19,9 @@ export function Header() {
     } catch (error) {
       // The signOut in SupabaseProvider currently doesn't throw errors, but this is for robustness
       console.error('Error during sign out process:', error);
-    } finally {
-      // Redirect to login page regardless of signOut success to ensure a clean state.
-      // The Supabase auth listener in SupabaseProvider should handle session changes and might reload.
-      router.push('/login');
-      // router.refresh(); // Optional: may help if immediate UI update needed beyond what listener does.
-                        // The listener in SupabaseProvider already calls window.location.reload().
     }
+  // The redirect to login page will now be handled by the onAuthStateChange listener
+  // in SupabaseProvider.
   };
 
   const menuItems: DropdownMenuItem[] = [

--- a/src/contexts/SupabaseProvider.tsx
+++ b/src/contexts/SupabaseProvider.tsx
@@ -52,20 +52,23 @@ export default function SupabaseProvider({
     getProfile()
   }, [session, supabase])
 
-  useEffect(() => {
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
-      async (event: AuthChangeEvent, currentSession: Session | null) => {
-        if (currentSession?.user.id !== session?.user.id) {
-          // Refresh the page on auth changes to ensure proper session state
-          window.location.reload()
-        }
+useEffect(() => {
+  const { data: { subscription } } = supabase.auth.onAuthStateChange(
+    async (event: AuthChangeEvent, currentSession: Session | null) => {
+      if (event === 'SIGNED_OUT') {
+        // Explicitly redirect to login page on sign out
+        window.location.href = '/login';
+      } else if (currentSession?.user.id !== session?.user.id) {
+        // Refresh the page on other auth changes to ensure proper session state
+        window.location.reload();
       }
-    )
-
-    return () => {
-      subscription.unsubscribe()
     }
-  }, [session?.user.id, supabase.auth])
+  );
+
+  return () => {
+    subscription.unsubscribe();
+  };
+}, [session?.user.id, supabase.auth, supabase]); // Added supabase to dependency array as it's used in the effect.
 
   const signOut = async () => {
     await supabase.auth.signOut()


### PR DESCRIPTION
This commit refines the user sign-out functionality:

1.  Centralizes post-sign-out redirection within `SupabaseProvider`. The `onAuthStateChange` listener in `SupabaseProvider.tsx` now handles redirecting you to the `/login` page upon a `SIGNED_OUT` event. This ensures a consistent redirection mechanism immediately after the authentication state changes.

2.  Simplifies `handlePerformSignOut` in `Header.tsx`. The `handlePerformSignOut` function now solely focuses on calling the `signOut` method obtained from the `useSupabase` context. The explicit `router.push('/login')` has been removed to prevent potential conflicts with the `onAuthStateChange` handler.

3.  The `supabase` client instance has been added to the `useEffect` dependency array in `SupabaseProvider.tsx` for correctness, as `supabase.auth` is used within the effect.

These changes aim to create a more robust and predictable sign-out experience, and also address the context of the originally reported error which likely stemmed from an older version of the `Header.tsx` component that checked for the Supabase client's existence differently.