### PR TITLE
Fix tooltip prop and vendor actions

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -294,9 +294,9 @@ async function DashboardContent({ searchParams }: { searchParams?: { mode?: stri
 				</div> {/* End of container */}
 
 				{/* Conditionally render VendorActions (FAB and Modal logic) */}
-				{profile && currentRole === 'vendor' && (
-					<VendorActions currentUserId={profile.id} />
-				)}
+                                {profile && currentRole === 'vendor' && (
+                                        <VendorActions />
+                                )}
 
 				{/* Footer - Ensure it's visually below the FAB or FAB avoids it */}
 				<footer className="mt-auto py-6 text-center border-t bg-white dark:bg-neutral-800 dark:border-neutral-700">

--- a/src/components/dashboard/VendorActions.tsx
+++ b/src/components/dashboard/VendorActions.tsx
@@ -6,11 +6,7 @@ import { Plus } from 'lucide-react';
 import { AddProductModal } from '@/components/products/AddProductModal';
 import { Button } from '@/components/ui/Button'; // If FAB is a styled Button, though not used in this example
 
-interface VendorActionsProps {
-  currentUserId: string;
-}
-
-export function VendorActions({ currentUserId }: VendorActionsProps) {
+export function VendorActions() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const router = useRouter();
 
@@ -37,7 +33,6 @@ export function VendorActions({ currentUserId }: VendorActionsProps) {
         isOpen={isModalOpen}
         onClose={handleCloseModal}
         onProductAdded={handleProductAdded}
-        currentUserId={currentUserId}
       />
     </>
   );

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -31,17 +31,19 @@ export function Tooltip({
   content,
   side = 'right',
   delayDuration = 0,
+  sideOffset = 4,
 }: {
   children: React.ReactNode
   content: React.ReactNode
   side?: 'top' | 'right' | 'bottom' | 'left'
   delayDuration?: number
+  sideOffset?: number
 }) {
   return (
     <TooltipProvider>
       <TooltipRoot delayDuration={delayDuration}>
         <TooltipTrigger asChild><span>{children}</span></TooltipTrigger>
-        <TooltipContent side={side}>{content}</TooltipContent>
+        <TooltipContent side={side} sideOffset={sideOffset}>{content}</TooltipContent>
       </TooltipRoot>
     </TooltipProvider>
   )


### PR DESCRIPTION
## Summary
- extend Tooltip to accept optional `sideOffset`
- remove unused `currentUserId` prop from `VendorActions`
- update dashboard page to use updated component

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6857dc710ed4832ba9c76dfae9406d41