### PR TITLE
Improve Next.js build for Vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,11 @@
 const path = require('path');
 
 const nextConfig = {
+  reactStrictMode: true,
+  output: 'standalone',
+  images: {
+    domains: ['via.placeholder.com', 'placehold.co'],
+  },
   webpack: (config) => {
     config.resolve.alias['@'] = path.join(__dirname, 'src');
     // Suppress Critical dependency warning for @supabase/realtime-js
@@ -9,8 +14,8 @@ const nextConfig = {
       ...(config.ignoreWarnings || []),
       {
         module: /@supabase[\\/]realtime-js/,
-        message: /Critical dependency: the request of a dependency is an expression/
-      }
+        message: /Critical dependency: the request of a dependency is an expression/,
+      },
     ];
     return config;
   },


### PR DESCRIPTION
## Summary
- tune Next.js configuration for Vercel deployment
- enable strict mode and standalone build
- allow placeholder image domains

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857e41b5204832bbe34b8bca5406663