### PR TITLE
Add chat inbox and conversation pages

### DIFF
--- a/src/app/inbox/[conversationId]/page.tsx
+++ b/src/app/inbox/[conversationId]/page.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { Header } from '@/components/layout/Header'
+import { useSupabase } from '@/contexts/SupabaseProvider'
+import { ChatHeader } from '@/components/chat/ChatHeader'
+import { ChatBubble } from '@/components/chat/ChatBubble'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import * as chatApi from '@/lib/supabase/chat'
+import { useMessages } from '@/hooks/useMessages'
+import type { Conversation } from '@/lib/supabase/chat'
+import { Button } from '@/components/ui/Button'
+
+export default function ChatPage() {
+  const params = useParams<{ conversationId: string }>()
+  const conversationId = params.conversationId
+  const { session } = useSupabase()
+  const userId = session?.user.id
+
+  const [conversation, setConversation] = useState<Conversation | null>(null)
+  const { messages, loading, sendMessage } = useMessages(conversationId)
+  const [input, setInput] = useState('')
+  const [loadingConversation, setLoadingConversation] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      if (!conversationId) return
+      try {
+        const data = await chatApi.getConversationById(conversationId)
+        setConversation(data)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setLoadingConversation(false)
+      }
+    }
+    load()
+  }, [conversationId])
+
+  const handleSend = async () => {
+    const text = input.trim()
+    if (!text || !userId) return
+    await sendMessage(userId, text)
+    setInput('')
+    const container = document.getElementById('messages-area')
+    if (container) container.scrollTop = container.scrollHeight
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="container mx-auto px-4 py-4">
+        <div className="mx-auto max-w-xl border rounded-lg shadow-sm bg-white flex flex-col h-[calc(100vh-12rem)] overflow-hidden">
+          {loadingConversation ? (
+            <div className="flex-1 flex items-center justify-center">
+              <LoadingSpinner />
+            </div>
+          ) : conversation ? (
+            <ChatHeader conversation={conversation} />
+          ) : (
+            <div className="p-4">Conversation not found</div>
+          )}
+
+          <div id="messages-area" className="flex-1 overflow-y-auto p-4 space-y-3">
+            {loading ? (
+              <div className="flex justify-center py-10">
+                <LoadingSpinner />
+              </div>
+            ) : (
+              messages.map(m => (
+                <ChatBubble key={m.id} message={m} currentUserId={userId!} />
+              ))
+            )}
+          </div>
+
+          <div className="border-t p-3 flex items-center gap-2">
+            <input
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  handleSend()
+                }
+              }}
+              placeholder="Type a message..."
+              className="flex-1 border rounded-full px-4 py-2"
+            />
+            <Button size="sm" onClick={handleSend}
+              className="send-btn rounded-full">
+              Send
+            </Button>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -1,25 +1,84 @@
 'use client'
 
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
-import { NotificationList } from '@/components/notifications/NotificationList'
+import { useState } from 'react'
+import { Header } from '@/components/layout/Header'
+import { useSupabase } from '@/contexts/SupabaseProvider'
+import { useConversations } from '@/hooks/useConversations'
+import { ConversationPreview } from '@/components/chat/ConversationPreview'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 
 export default function InboxPage() {
-  return (
-    <div className="space-y-8">
-      <div className="flex items-center justify-between">
-        <h2 className="text-3xl font-bold tracking-tight">Inbox</h2>
-      </div>
+  const { session } = useSupabase()
+  const userId = session?.user.id
+  const { conversations, loading } = useConversations(userId)
 
-      <div className="grid gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Notifications</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <NotificationList />
-          </CardContent>
-        </Card>
-      </div>
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState<'all' | 'unread' | 'personal' | 'business'>('all')
+
+  const filtered = conversations.filter(c => {
+    const matchesFilter =
+      filter === 'all' ||
+      (filter === 'unread' && c.unread_count > 0) ||
+      (filter === 'personal' && (c.type === 'personal' || c.type === 'group')) ||
+      (filter === 'business' && c.type === 'business')
+
+    const term = search.toLowerCase()
+    const matchesSearch =
+      c.name.toLowerCase().includes(term) ||
+      (c.last_message ?? '').toLowerCase().includes(term)
+
+    return matchesFilter && matchesSearch
+  })
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Header />
+      <main className="container mx-auto px-4 py-8">
+        <div className="max-w-xl mx-auto">
+          <div className="mb-6">
+            <h1 className="flex items-center gap-2 text-3xl font-bold text-primary mb-4">Chats</h1>
+            <div className="relative mb-4">
+              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground">🔍</span>
+              <input
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                placeholder="Search chats..."
+                className="w-full border rounded-md px-3 py-2 pl-8"
+              />
+            </div>
+            <div className="flex gap-2">
+              {([
+                ['all', 'All'],
+                ['unread', 'Unread'],
+                ['personal', 'Personal'],
+                ['business', 'Business'],
+              ] as const).map(([value, label]) => (
+                <button
+                  key={value}
+                  onClick={() => setFilter(value as any)}
+                  className={`px-3 py-1 rounded-md border text-sm ${filter === value ? 'bg-primary text-white border-primary' : 'bg-white'}`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {loading ? (
+            <div className="flex justify-center py-10">
+              <LoadingSpinner />
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-center text-sm text-muted-foreground py-20">No chats found.</p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {filtered.map(convo => (
+                <ConversationPreview key={convo.id} conversation={convo} />
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
     </div>
   )
 }

--- a/src/components/chat/ChatBubble.tsx
+++ b/src/components/chat/ChatBubble.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { Avatar } from '@/components/ui/Avatar'
+import type { Message } from '@/lib/supabase/chat'
+import { cn } from '@/lib/utils'
+
+interface ChatBubbleProps {
+  message: Message
+  currentUserId: string
+}
+
+export function ChatBubble({ message, currentUserId }: ChatBubbleProps) {
+  const isSent = message.sender_id === currentUserId
+
+  return (
+    <div className={cn('flex items-end gap-2 max-w-[80%]', isSent ? 'ml-auto flex-row-reverse' : '')}>
+      {!isSent && (
+        <Avatar src={message.sender_avatar_url ?? undefined} alt={message.sender_name} size={32} />
+      )}
+      <div
+        className={cn(
+          'px-3 py-2 rounded-lg text-sm break-words',
+          isSent ? 'bg-primary text-white' : 'bg-gray-100'
+        )}
+      >
+        {message.content}
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+import { Avatar } from '@/components/ui/Avatar'
+import type { Conversation } from '@/lib/supabase/chat'
+import { Button } from '@/components/ui/Button'
+
+interface ChatHeaderProps {
+  conversation: Conversation
+}
+
+export function ChatHeader({ conversation }: ChatHeaderProps) {
+  return (
+    <div className="flex items-center gap-3 border-b p-3 flex-shrink-0">
+      <Link href="/inbox">
+        <Button variant="ghost" size="sm">
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+      </Link>
+      <Avatar src={conversation.avatar_url ?? undefined} alt={conversation.name} size={40} />
+      <div>
+        <p className="font-medium leading-none">{conversation.name}</p>
+        <p className="text-xs text-green-600">Online</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/ConversationPreview.tsx
+++ b/src/components/chat/ConversationPreview.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import Link from 'next/link'
+import { Avatar } from '@/components/ui/Avatar'
+import type { Conversation } from '@/lib/supabase/chat'
+import { formatDistanceToNow } from 'date-fns'
+import { cn } from '@/lib/utils'
+
+interface ConversationPreviewProps {
+  conversation: Conversation
+}
+
+export function ConversationPreview({ conversation }: ConversationPreviewProps) {
+  return (
+    <Link
+      href={`/inbox/${conversation.id}`}
+      className={cn(
+        'flex items-center gap-4 p-3 rounded-lg border transition-colors',
+        conversation.unread_count > 0
+          ? 'bg-blue-50 border-blue-200'
+          : 'bg-white hover:bg-gray-50'
+      )}
+    >
+      <Avatar src={conversation.avatar_url ?? undefined} alt={conversation.name} size={48} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between">
+          <p className="font-medium truncate">{conversation.name}</p>
+          <time className="ml-2 text-xs text-muted-foreground">
+            {formatDistanceToNow(new Date(conversation.updated_at), { addSuffix: true })}
+          </time>
+        </div>
+        <div className="flex items-center justify-between mt-1">
+          <p className="text-sm text-muted-foreground truncate">
+            {conversation.last_message || ''}
+          </p>
+          {conversation.unread_count > 0 && (
+            <span className="ml-2 text-xs rounded-full bg-amber-500 text-white w-5 h-5 flex items-center justify-center">
+              {conversation.unread_count}
+            </span>
+          )}
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/src/hooks/useConversations.ts
+++ b/src/hooks/useConversations.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react'
+import * as chatApi from '@/lib/supabase/chat'
+import type { Conversation } from '@/lib/supabase/chat'
+
+export function useConversations(userId: string | undefined) {
+  const [conversations, setConversations] = useState<Conversation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      if (!userId) return
+
+      try {
+        const data = await chatApi.getConversations(userId)
+        setConversations(data)
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to load conversations'))
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
+  }, [userId])
+
+  return { conversations, loading, error }
+}

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import * as chatApi from '@/lib/supabase/chat'
+import type { Message } from '@/lib/supabase/chat'
+
+export function useMessages(conversationId: string | undefined) {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      if (!conversationId) return
+
+      try {
+        const data = await chatApi.getMessages(conversationId)
+        setMessages(data)
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to load messages'))
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
+  }, [conversationId])
+
+  const sendMessage = async (senderId: string, content: string) => {
+    if (!conversationId) return
+    const newMsg = await chatApi.sendMessage(conversationId, senderId, content)
+    setMessages(prev => [...prev, newMsg])
+  }
+
+  return { messages, loading, error, sendMessage }
+}

--- a/src/lib/supabase/chat.ts
+++ b/src/lib/supabase/chat.ts
@@ -1,0 +1,70 @@
+import supabaseClient from './supabaseClient'
+
+export interface Conversation {
+  id: string
+  name: string
+  type: 'personal' | 'business' | 'group'
+  avatar_url: string | null
+  last_message: string | null
+  updated_at: string
+  unread_count: number
+}
+
+export interface Message {
+  id: string
+  conversation_id: string
+  sender_id: string
+  sender_name: string
+  sender_avatar_url: string | null
+  content: string
+  created_at: string
+  read: boolean
+}
+
+export async function getConversations(userId: string) {
+  const { data, error } = await supabaseClient
+    .from('conversations')
+    .select(`id, name, type, avatar_url, last_message, updated_at, unread_count`)
+    .eq('user_id', userId)
+    .order('updated_at', { ascending: false })
+
+  if (error) throw error
+  return (data as any) as Conversation[]
+}
+
+export async function getConversationById(id: string) {
+  const { data, error } = await supabaseClient
+    .from('conversations')
+    .select(`id, name, type, avatar_url, last_message, updated_at, unread_count`)
+    .eq('id', id)
+    .single()
+
+  if (error) throw error
+  return data as Conversation
+}
+
+export async function getMessages(conversationId: string) {
+  const { data, error } = await supabaseClient
+    .from('messages')
+    .select(
+      `id, conversation_id, sender_id, sender_name, sender_avatar_url, content, created_at, read`
+    )
+    .eq('conversation_id', conversationId)
+    .order('created_at', { ascending: true })
+
+  if (error) throw error
+  return (data as any) as Message[]
+}
+
+export async function sendMessage(conversationId: string, senderId: string, content: string) {
+  const { data, error } = await supabaseClient
+    .from('messages')
+    .insert({ conversation_id: conversationId, sender_id: senderId, content })
+    .select(
+      `id, conversation_id, sender_id, sender_name, sender_avatar_url, content, created_at, read`
+    )
+    .single()
+
+  if (error) throw error
+  return data as Message
+}


### PR DESCRIPTION
## Summary
- transform Inbox into chat list with search and filters
- add chat conversation page with message bubbles
- implement hooks for conversations and messages
- add Supabase chat helpers

## Testing
- `npm install`
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c765f5d34832b8141953a01a1baae