### PR TITLE
Implement wallet payment & vendor bank form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@supabase/auth-ui-shared": "^0.1.8",
         "@supabase/supabase-js": "^2.50.0",
         "autoprefixer": "^10.4.18",
+        "axios": "^1.6.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -5039,7 +5040,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
@@ -5103,6 +5103,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -5378,7 +5389,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5687,7 +5697,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -6198,7 +6207,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -6306,7 +6314,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -6467,7 +6474,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6477,7 +6483,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6515,7 +6520,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6528,7 +6532,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7278,6 +7281,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -7314,7 +7337,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
       "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -7425,7 +7447,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7460,7 +7481,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7591,7 +7611,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7670,7 +7689,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7683,7 +7701,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -9782,7 +9799,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9821,7 +9837,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9831,7 +9846,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -11387,6 +11401,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@supabase/auth-ui-shared": "^0.1.8",
     "@supabase/supabase-js": "^2.50.0",
     "autoprefixer": "^10.4.18",
+    "axios": "^1.6.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/src/app/api/group-payment/route.ts
+++ b/src/app/api/group-payment/route.ts
@@ -1,0 +1,79 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import axios from 'axios'
+import type { Database } from '@/types/database.types'
+
+export async function POST(req: Request) {
+  const supabase = createRouteHandlerClient<Database>({ cookies })
+  const { data: { session } } = await supabase.auth.getSession()
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { groupId, amount } = await req.json()
+  const { data: profile, error } = await supabase
+    .from('user_profiles')
+    .select('wallet_balance')
+    .eq('id', session.user.id)
+    .single()
+
+  if (error || !profile) {
+    return NextResponse.json({ error: 'Failed to fetch wallet' }, { status: 500 })
+  }
+
+  if (profile.wallet_balance >= amount) {
+    const newBalance = profile.wallet_balance - amount
+    const { error: updateError } = await supabase
+      .from('user_profiles')
+      .update({ wallet_balance: newBalance })
+      .eq('id', session.user.id)
+
+    if (updateError) {
+      return NextResponse.json({ error: 'Failed to debit wallet' }, { status: 500 })
+    }
+
+    await supabase.from('transactions').insert({
+      user_id: session.user.id,
+      amount,
+      type: 'escrow',
+      status: 'completed',
+      reference_id: groupId,
+      description: 'Group payment from wallet',
+    })
+
+    return NextResponse.json({ status: 'paid_from_wallet' })
+  }
+
+  const PAYSTACK_SECRET = process.env.PAYSTACK_SECRET_KEY
+  if (!PAYSTACK_SECRET) {
+    return NextResponse.json({ error: 'Paystack not configured' }, { status: 500 })
+  }
+
+  try {
+    const { data: paystackRes } = await axios.post(
+      'https://api.paystack.co/transaction/initialize',
+      {
+        email: session.user.email,
+        amount: amount * 100,
+        metadata: { groupId },
+      },
+      { headers: { Authorization: `Bearer ${PAYSTACK_SECRET}`, 'Content-Type': 'application/json' } }
+    )
+
+    const { authorization_url, reference } = paystackRes.data
+    await supabase.from('transactions').insert({
+      user_id: session.user.id,
+      amount,
+      type: 'escrow',
+      status: 'pending',
+      reference_id: reference,
+      description: 'Group payment via paystack',
+    })
+
+    return NextResponse.json({ paymentUrl: authorization_url })
+  } catch (err: any) {
+    console.error('Paystack error', err.response?.data || err.message)
+    return NextResponse.json({ error: 'Payment initialization failed' }, { status: 500 })
+  }
+}

--- a/src/app/profile/__tests__/page.test.tsx
+++ b/src/app/profile/__tests__/page.test.tsx
@@ -30,6 +30,14 @@ jest.mock('@/components/layout/Header', () => {
   };
 });
 
+// Mock VendorBankForm to avoid loading client-specific modules
+jest.mock('@/components/profile/VendorBankForm', () => {
+  return {
+    __esModule: true,
+    VendorBankForm: () => <div data-testid="mock-bank-form">Mock Bank Form</div>,
+  };
+});
+
 // Mock Image component
 jest.mock('next/image', () => ({
     __esModule: true,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,7 +3,8 @@ import { Header } from '@/components/layout/Header'
 import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
-import { User, Wallet, Settings, Bell } from 'lucide-react'
+import { User, Wallet, Settings, Bell, Banknote } from 'lucide-react'
+import { VendorBankForm } from '@/components/profile/VendorBankForm'
 import Image from 'next/image'
 import type { Session } from '@supabase/supabase-js' // Import Session type
 
@@ -121,6 +122,24 @@ export default async function ProfilePage() {
                 </CardContent>
               </Card>
 
+              {profile?.role === 'vendor' && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center space-x-2">
+                      <Banknote className="h-5 w-5" />
+                      <span>Vendor Payout Details</span>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <VendorBankForm
+                      initialAccountNumber={profile.account_number || ''}
+                      initialBankCode={profile.bank_code || ''}
+                      initialCurrency={profile.currency || 'NGN'}
+                    />
+                  </CardContent>
+                </Card>
+              )}
+
               <Card>
                 <CardHeader>
                   <CardTitle className="flex items-center space-x-2">
@@ -137,6 +156,10 @@ export default async function ProfilePage() {
                     <div>
                       <p className="text-sm text-muted-foreground">Holds</p>
                       <p className="text-xl font-semibold">${profile?.holds || '0.00'}</p>
+                    </div>
+                    <div className="flex gap-2 pt-2">
+                      <button className="rounded-lg bg-primary px-3 py-2 text-sm font-medium text-white">Fund</button>
+                      <button className="rounded-lg bg-muted px-3 py-2 text-sm font-medium">Withdraw</button>
                     </div>
                   </div>
                 </CardContent>

--- a/src/components/profile/VendorBankForm.tsx
+++ b/src/components/profile/VendorBankForm.tsx
@@ -1,0 +1,80 @@
+'use client'
+import { useState } from 'react'
+import { useSupabase } from '@/contexts/SupabaseProvider'
+import { Button } from '@/components/ui/Button'
+
+interface VendorBankFormProps {
+  initialAccountNumber?: string
+  initialBankCode?: string
+  initialCurrency?: string
+}
+
+export function VendorBankForm({
+  initialAccountNumber = '',
+  initialBankCode = '',
+  initialCurrency = 'NGN',
+}: VendorBankFormProps) {
+  const { updateProfile } = useSupabase()
+  const [accountNumber, setAccountNumber] = useState(initialAccountNumber)
+  const [bankCode, setBankCode] = useState(initialBankCode)
+  const [currency, setCurrency] = useState(initialCurrency)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    try {
+      await updateProfile({ account_number: accountNumber, bank_code: bankCode, currency })
+      alert('Bank details updated')
+    } catch (err) {
+      setError('Failed to update details')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <label htmlFor="accountNumber" className="text-sm font-medium">Account Number</label>
+        <input
+          id="accountNumber"
+          type="text"
+          value={accountNumber}
+          onChange={(e) => setAccountNumber(e.target.value)}
+          className="w-full rounded-lg border bg-background px-3 py-2"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="bankCode" className="text-sm font-medium">Bank Code</label>
+        <input
+          id="bankCode"
+          type="text"
+          value={bankCode}
+          onChange={(e) => setBankCode(e.target.value)}
+          className="w-full rounded-lg border bg-background px-3 py-2"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <label htmlFor="currency" className="text-sm font-medium">Currency</label>
+        <select
+          id="currency"
+          value={currency}
+          onChange={(e) => setCurrency(e.target.value)}
+          className="w-full rounded-lg border bg-background px-3 py-2"
+        >
+          <option value="NGN">NGN</option>
+          <option value="USD" disabled>USD</option>
+        </select>
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <Button type="submit" disabled={loading} className="mt-2">
+        {loading ? 'Saving...' : 'Save'}
+      </Button>
+    </form>
+  )
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -64,7 +64,10 @@ export async function getUserProfile() {
           avatar_url: user.user_metadata?.avatar_url ?? null, // Safe access
           role: 'buyer', // Default role
           wallet_balance: 0,
-            holds: 0,
+          holds: 0,
+          account_number: null,
+          bank_code: null,
+          currency: 'NGN',
           })
           .select()
           .single();

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -24,6 +24,9 @@ export interface Database {
           role: UserRole
           wallet_balance: number
           holds: number
+          account_number: string | null
+          bank_code: string | null
+          currency: string | null
           created_at: string
           updated_at: string
         }
@@ -34,6 +37,9 @@ export interface Database {
           role?: UserRole
           wallet_balance?: number
           holds?: number
+          account_number?: string | null
+          bank_code?: string | null
+          currency?: string | null
           created_at?: string
           updated_at?: string
         }
@@ -44,6 +50,9 @@ export interface Database {
           role?: UserRole
           wallet_balance?: number
           holds?: number
+          account_number?: string | null
+          bank_code?: string | null
+          currency?: string | null
           created_at?: string
           updated_at?: string
         }


### PR DESCRIPTION
## Summary
- extend `user_profiles` table types with vendor bank fields
- default vendor fields when creating a profile
- add API route for paying from wallet or initializing Paystack
- add vendor payout details form and wallet buttons on profile page
- update profile tests to mock new form
- include axios dependency

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685e01a0f694832baf632d9f5c74c1e1