### PR TITLE
Implement payout editing

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,7 +4,7 @@ import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
 import { User, Wallet, Settings, Bell, Banknote } from 'lucide-react'
-import { VendorBankForm } from '@/components/profile/VendorBankForm'
+import { BankDetailsToggle } from '@/components/profile/BankDetailsToggle'
 import Image from 'next/image'
 import type { Session } from '@supabase/supabase-js' // Import Session type
 
@@ -122,23 +122,21 @@ export default async function ProfilePage() {
                 </CardContent>
               </Card>
 
-              {profile?.role === 'vendor' && (
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center space-x-2">
-                      <Banknote className="h-5 w-5" />
-                      <span>Vendor Payout Details</span>
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent>
-                    <VendorBankForm
-                      initialAccountNumber={profile.account_number || ''}
-                      initialBankCode={profile.bank_code || ''}
-                      initialCurrency={profile.currency || 'NGN'}
-                    />
-                  </CardContent>
-                </Card>
-              )}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center space-x-2">
+                    <Banknote className="h-5 w-5" />
+                    <span>Payout Details</span>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <BankDetailsToggle
+                    initialAccountNumber={profile.account_number || ''}
+                    initialBankCode={profile.bank_code || ''}
+                    initialCurrency={profile.currency || 'NGN'}
+                  />
+                </CardContent>
+              </Card>
 
               <Card>
                 <CardHeader>

--- a/src/components/profile/BankDetailsToggle.tsx
+++ b/src/components/profile/BankDetailsToggle.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import { VendorBankForm } from './VendorBankForm'
+
+interface BankDetailsToggleProps {
+  initialAccountNumber?: string
+  initialBankCode?: string
+  initialCurrency?: string
+}
+
+export function BankDetailsToggle({
+  initialAccountNumber = '',
+  initialBankCode = '',
+  initialCurrency = 'NGN',
+}: BankDetailsToggleProps) {
+  const [showForm, setShowForm] = useState(false)
+
+  return (
+    <div className="space-y-4">
+      {showForm ? (
+        <VendorBankForm
+          initialAccountNumber={initialAccountNumber}
+          initialBankCode={initialBankCode}
+          initialCurrency={initialCurrency}
+        />
+      ) : (
+        <Button type="button" onClick={() => setShowForm(true)}>
+          Update Bank Details
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -65,10 +65,7 @@ export async function getUserProfile() {
           role: 'buyer', // Default role
           wallet_balance: 0,
           holds: 0,
-          account_number: null,
-          bank_code: null,
-          currency: 'NGN',
-          })
+        })
           .select()
           .single();
 


### PR DESCRIPTION
## Summary
- enable payout editing for every user on the profile page
- add toggle component so bank details can be added when desired
- remove default banking fields from server profile creation

## Testing
- `npm install`
- `npm run build` *(fails: Missing env.NEXT_PUBLIC_SUPABASE_URL)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e102633c4832b8a3ae5e7b0b107ae