### PR TITLE
Update payout info to use bank_name field

### DIFF
--- a/src/app/api/update-payout-info/route.ts
+++ b/src/app/api/update-payout-info/route.ts
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
 export async function POST(request: Request) {
-  const { account_name, account_number, bank_code, currency } = await request.json()
+  const { account_name, account_number, bank_name, currency } = await request.json()
   const supabase = createRouteHandlerClient({ cookies })
   const {
     data: { user },
@@ -14,7 +14,7 @@ export async function POST(request: Request) {
   }
   const { error } = await supabase
     .from('user_profiles')
-    .update({ account_name, account_number, bank_code, currency })
+    .update({ account_name, account_number, bank_name, currency })
     .eq('id', user.id)
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -158,7 +158,7 @@ export default async function ProfilePage() {
                   <PayoutInfo
                     account_name={profile?.account_name}
                     account_number={profile?.account_number}
-                    bank_code={profile?.bank_code}
+                    bank_name={profile?.bank_name}
                     currency={profile?.currency}
                   />
                 </CardContent>

--- a/src/components/profile/PayoutInfo.tsx
+++ b/src/components/profile/PayoutInfo.tsx
@@ -5,13 +5,13 @@ import { Button } from '@/components/ui/Button'
 interface Props {
   account_name?: string | null
   account_number?: string | null
-  bank_code?: string | null
+  bank_name?: string | null
   currency?: string | null
 }
 
-export default function PayoutInfo({ account_name, account_number, bank_code, currency }: Props) {
+export default function PayoutInfo({ account_name, account_number, bank_name, currency }: Props) {
   const [editing, setEditing] = useState(false)
-  const [form, setForm] = useState({ account_name: account_name || '', account_number: account_number || '', bank_code: bank_code || '', currency: currency || 'NGN' })
+  const [form, setForm] = useState({ account_name: account_name || '', account_number: account_number || '', bank_name: bank_name || '', currency: currency || 'NGN' })
   const toggle = () => setEditing(v => !v)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
@@ -33,7 +33,7 @@ export default function PayoutInfo({ account_name, account_number, bank_code, cu
         <>
           <p className="text-sm text-muted-foreground">Account Name: {account_name || 'N/A'}</p>
           <p className="text-sm text-muted-foreground">Account Number: {account_number || 'N/A'}</p>
-          <p className="text-sm text-muted-foreground">Bank Code: {bank_code || 'N/A'}</p>
+          <p className="text-sm text-muted-foreground">Bank Name: {bank_name || 'N/A'}</p>
           <p className="text-sm text-muted-foreground">Currency: {currency || 'N/A'}</p>
           <Button onClick={toggle} className="mt-2">Update</Button>
         </>
@@ -42,7 +42,7 @@ export default function PayoutInfo({ account_name, account_number, bank_code, cu
         <div className="space-y-2">
           <input name="account_name" value={form.account_name} onChange={handleChange} placeholder="Name" className="w-full border rounded px-2 py-1" />
           <input name="account_number" value={form.account_number} onChange={handleChange} placeholder="Account Number" className="w-full border rounded px-2 py-1" />
-          <input name="bank_code" value={form.bank_code} onChange={handleChange} placeholder="Bank Code" className="w-full border rounded px-2 py-1" />
+          <input name="bank_name" value={form.bank_name} onChange={handleChange} placeholder="Bank Name" className="w-full border rounded px-2 py-1" />
           <select name="currency" value={form.currency} onChange={handleChange} className="w-full border rounded px-2 py-1">
             <option value="NGN">NGN</option>
             <option value="USD" disabled>USD</option>

--- a/src/lib/supabase/user.ts
+++ b/src/lib/supabase/user.ts
@@ -18,7 +18,7 @@ export async function updateUserProfile(userId: string, updates: {
   role?: UserRole
   account_name?: string | null
   account_number?: string | null
-  bank_code?: string | null
+  bank_name?: string | null
   currency?: string | null
 }) {
   const { data, error } = await supabaseClient
@@ -39,7 +39,7 @@ export async function createUserProfile(profile: {
   role: UserRole
   account_name?: string | null
   account_number?: string | null
-  bank_code?: string | null
+  bank_name?: string | null
   currency?: string | null
 }) {
   const { data, error } = await supabaseClient
@@ -50,7 +50,7 @@ export async function createUserProfile(profile: {
       holds: 0,
       account_name: profile.account_name ?? null,
       account_number: profile.account_number ?? null,
-      bank_code: profile.bank_code ?? null,
+      bank_name: profile.bank_name ?? null,
       currency: profile.currency ?? null,
     })
     .select()

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -26,7 +26,7 @@ export interface Database {
           holds: number
           account_name: string | null
           account_number: string | null
-          bank_code: string | null
+          bank_name: string | null
           currency: string | null
           created_at: string
           updated_at: string
@@ -40,7 +40,7 @@ export interface Database {
           holds?: number
           account_name?: string | null
           account_number?: string | null
-          bank_code?: string | null
+          bank_name?: string | null
           currency?: string | null
           created_at?: string
           updated_at?: string
@@ -54,7 +54,7 @@ export interface Database {
           holds?: number
           account_name?: string | null
           account_number?: string | null
-          bank_code?: string | null
+          bank_name?: string | null
           currency?: string | null
           created_at?: string
           updated_at?: string


### PR DESCRIPTION
## Summary
- update user profile type to use `bank_name`
- adjust supabase user helpers for `bank_name`
- update API route to save `bank_name`
- update profile page payout info component
- replace bank code field with bank name

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Missing env.NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_685e2949df0c832bb48989445cf125fe