### PR TITLE
Add credential notification after group approval

### DIFF
--- a/src/lib/supabase/notifications.ts
+++ b/src/lib/supabase/notifications.ts
@@ -11,6 +11,26 @@ export type Notification = {
   created_at: string
 }
 
+export async function createNotification(notification: {
+  user_id: string
+  title: string
+  message: string
+  type?: 'info' | 'success' | 'warning' | 'error'
+  link?: string
+}) {
+  const { data, error } = await supabaseClient
+    .from('notifications')
+    .insert({
+      ...notification,
+      type: notification.type ?? 'info',
+    })
+    .select()
+    .single()
+
+  if (error) throw error
+  return data as Notification
+}
+
 export async function getNotifications(userId: string) {
   const { data, error } = await supabaseClient
     .from('notifications')


### PR DESCRIPTION
## Summary
- notify group members with software subscription credentials when voting is unanimously approved
- expose `createNotification` util for inserting notifications

## Testing
- `npm install`
- `npm test`
- `npm run build` *(fails: Missing env.NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_685e349c9c70832ba17c3ee0b5857d5c