### PR TITLE
Implement chat interface

### DIFF
--- a/src/app/inbox/[id]/page.tsx
+++ b/src/app/inbox/[id]/page.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useParams } from 'next/navigation'
+import { useSupabase } from '@/contexts/SupabaseProvider'
+import { useMessages } from '@/hooks/useConversations'
+import { ChatBubble } from '@/components/chat/ChatBubble'
+import { ChatHeader } from '@/components/chat/ChatHeader'
+import { MessageInput } from '@/components/chat/MessageInput'
+import { useEffect, useRef, useState } from 'react'
+import * as chatApi from '@/lib/supabase/chat'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+
+export default function ChatDetailPage() {
+  const params = useParams<{ id: string }>()
+  const conversationId = params.id
+  const { profile } = useSupabase()
+  const { messages, loading, sendMessage } = useMessages(conversationId)
+  const [conversation, setConversation] = useState<chatApi.Conversation | null>(null)
+  const messagesEndRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      if (profile?.id && conversationId) {
+        try {
+          const convs = await chatApi.getConversations(profile.id)
+          const conv = convs.find(c => c.id === conversationId) || null
+          setConversation(conv)
+        } catch (e) {
+          console.error(e)
+        }
+      }
+    }
+    load()
+  }, [profile?.id, conversationId])
+
+  const handleSend = (text: string) => {
+    if (!profile) return
+    sendMessage(profile.id, text)
+  }
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  if (loading && !conversation) {
+    return <div className="flex justify-center p-10"><LoadingSpinner /></div>
+  }
+
+  if (!conversation) return null
+
+  return (
+    <div className="mx-auto flex h-[calc(100vh-10rem)] max-w-2xl flex-col rounded-md border shadow-sm">
+      <ChatHeader name={conversation.name} avatarUrl={conversation.avatar_url} />
+      <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-3" id="messages">
+        {messages.map(m => (
+          <ChatBubble
+            key={m.id}
+            message={m}
+            isOwn={m.sender_id === profile?.id}
+            showSender={conversation.type === 'group'}
+            senderName={m.sender_id === profile?.id ? 'You' : ''}
+          />
+        ))}
+        <div ref={messagesEndRef} />
+      </div>
+      <MessageInput onSend={handleSend} />
+    </div>
+  )
+}

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -1,25 +1,71 @@
 'use client'
 
-import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
-import { NotificationList } from '@/components/notifications/NotificationList'
+import { useSupabase } from '@/contexts/SupabaseProvider'
+import { useConversations } from '@/hooks/useConversations'
+import { ConversationPreview } from '@/components/chat/ConversationPreview'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import { useState } from 'react'
+import { Button } from '@/components/ui/Button'
 
 export default function InboxPage() {
-  return (
-    <div className="space-y-8">
-      <div className="flex items-center justify-between">
-        <h2 className="text-3xl font-bold tracking-tight">Inbox</h2>
-      </div>
+  const { profile } = useSupabase()
+  const { conversations, loading } = useConversations(profile?.id)
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState<'all' | 'unread' | 'personal' | 'business'>('all')
 
-      <div className="grid gap-6">
-        <Card>
-          <CardHeader>
-            <CardTitle>Notifications</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <NotificationList />
-          </CardContent>
-        </Card>
+  const filtered = conversations.filter(c => {
+    const matchesFilter =
+      filter === 'all' ||
+      (filter === 'unread' && c.unread_count > 0) ||
+      (filter === 'personal' && (c.type === 'personal' || c.type === 'group')) ||
+      (filter === 'business' && c.type === 'business')
+    const term = search.toLowerCase()
+    const matchesSearch =
+      c.name.toLowerCase().includes(term) ||
+      (c.last_message ?? '').toLowerCase().includes(term)
+    return matchesFilter && matchesSearch
+  })
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold text-primary">Chats</h1>
+      <div className="space-y-4">
+        <div className="relative">
+          <input
+            type="text"
+            placeholder="Search chats..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="w-full rounded-md border px-3 py-2 pl-8 text-sm"
+          />
+          <span className="absolute left-2 top-2.5 text-gray-400">🔍</span>
+        </div>
+        <div className="flex gap-2">
+          {(['all', 'unread', 'personal', 'business'] as const).map(f => (
+            <Button
+              key={f}
+              size="sm"
+              variant={filter === f ? 'default' : 'outline'}
+              onClick={() => setFilter(f)}
+            >
+              {f.charAt(0).toUpperCase() + f.slice(1)}
+            </Button>
+          ))}
+        </div>
       </div>
+      {loading ? (
+        <div className="flex justify-center p-8">
+          <LoadingSpinner />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {filtered.length === 0 ? (
+            <p className="p-4 text-center text-sm text-gray-500">No chats found.</p>
+          ) : (
+            filtered.map(c => <ConversationPreview key={c.id} conversation={c} />)
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/chat/ChatBubble.tsx
+++ b/src/components/chat/ChatBubble.tsx
@@ -1,0 +1,27 @@
+import { Avatar } from '@/components/ui/Avatar'
+import type { Message } from '@/lib/supabase/chat'
+import { cn } from '@/lib/utils'
+
+interface Props {
+  message: Message
+  isOwn: boolean
+  showSender?: boolean
+  senderName?: string
+  senderAvatar?: string | null
+}
+
+export function ChatBubble({ message, isOwn, showSender, senderName, senderAvatar }: Props) {
+  return (
+    <div className={cn('flex max-w-[80%] items-end gap-2', isOwn ? 'ml-auto flex-row-reverse' : '')}>
+      {!isOwn && (
+        <Avatar src={senderAvatar ?? undefined} alt={senderName ?? ''} size={32} />
+      )}
+      <div className={cn('rounded-xl px-3 py-2 text-sm', isOwn ? 'bg-blue-500 text-white rounded-br-sm' : 'bg-gray-100 text-gray-800 rounded-bl-sm')}>
+        {showSender && !isOwn && senderName && (
+          <div className="mb-1 text-xs font-medium text-gray-500">{senderName}</div>
+        )}
+        <div>{message.content}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link'
+import { ArrowLeft, Phone, Video } from 'lucide-react'
+import { Avatar } from '@/components/ui/Avatar'
+
+interface Props {
+  name: string
+  avatarUrl: string | null
+}
+
+export function ChatHeader({ name, avatarUrl }: Props) {
+  return (
+    <div className="flex items-center gap-2 border-b p-3">
+      <Link href="/inbox" className="text-gray-600 hover:text-gray-800">
+        <ArrowLeft />
+      </Link>
+      <Avatar src={avatarUrl ?? undefined} alt={name} size={40} />
+      <div className="ml-2 flex flex-col">
+        <span className="font-medium">{name}</span>
+        <span className="text-xs text-green-600">Online</span>
+      </div>
+      <div className="ml-auto flex gap-2 text-gray-500">
+        <button disabled>
+          <Video size={20} />
+        </button>
+        <button disabled>
+          <Phone size={20} />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/chat/ConversationPreview.tsx
+++ b/src/components/chat/ConversationPreview.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link'
+import { Avatar } from '@/components/ui/Avatar'
+import type { Conversation } from '@/lib/supabase/chat'
+import { formatDistanceToNow } from 'date-fns'
+import { cn } from '@/lib/utils'
+
+interface Props {
+  conversation: Conversation
+}
+
+export function ConversationPreview({ conversation }: Props) {
+  return (
+    <Link
+      href={`/inbox/${conversation.id}`}
+      className={cn(
+        'flex gap-4 rounded-md border p-3 transition-colors hover:bg-gray-50',
+        !conversation.unread_count ? '' : 'bg-blue-50 border-l-4 border-blue-400'
+      )}
+    >
+      <Avatar src={conversation.avatar_url ?? undefined} alt={conversation.name} size={48} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex justify-between items-center">
+          <span className="font-medium truncate">{conversation.name}</span>
+          {conversation.last_message_at && (
+            <span className="ml-2 text-xs text-gray-500 whitespace-nowrap">
+              {formatDistanceToNow(new Date(conversation.last_message_at), { addSuffix: true })}
+            </span>
+          )}
+        </div>
+        <div className="flex justify-between mt-1 items-start">
+          <span className="text-sm text-gray-600 truncate flex-1">{conversation.last_message}</span>
+          {conversation.unread_count > 0 && (
+            <span className="ml-2 flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs text-white">
+              {conversation.unread_count}
+            </span>
+          )}
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/src/components/chat/MessageInput.tsx
+++ b/src/components/chat/MessageInput.tsx
@@ -1,0 +1,44 @@
+import { Send, Smile, Paperclip } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/Button'
+
+interface Props {
+  onSend: (text: string) => void
+}
+
+export function MessageInput({ onSend }: Props) {
+  const [text, setText] = useState('')
+
+  const handleSend = () => {
+    const value = text.trim()
+    if (!value) return
+    onSend(value)
+    setText('')
+  }
+
+  return (
+    <div className="flex items-center gap-2 border-t bg-gray-50 p-3">
+      <button disabled className="text-gray-500">
+        <Smile size={20} />
+      </button>
+      <button disabled className="text-gray-500">
+        <Paperclip size={20} />
+      </button>
+      <input
+        className="flex-1 rounded-full border px-3 py-2 text-sm"
+        placeholder="Type a message..."
+        value={text}
+        onChange={e => setText(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            handleSend()
+          }
+        }}
+      />
+      <Button size="sm" onClick={handleSend} className="rounded-full px-2">
+        <Send size={18} />
+      </Button>
+    </div>
+  )
+}

--- a/src/hooks/useConversations.ts
+++ b/src/hooks/useConversations.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react'
+import * as chatApi from '@/lib/supabase/chat'
+
+export function useConversations(userId: string | undefined) {
+  const [conversations, setConversations] = useState<chatApi.Conversation[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      if (!userId) return
+
+      try {
+        const data = await chatApi.getConversations(userId)
+        setConversations(data)
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to load conversations'))
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
+  }, [userId])
+
+  return { conversations, loading, error }
+}
+
+export function useMessages(conversationId: string | undefined) {
+  const [messages, setMessages] = useState<chatApi.Message[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (!conversationId) return
+    const id = conversationId
+
+    let subscription: any
+
+    async function load() {
+      try {
+        const data = await chatApi.getMessages(id)
+        setMessages(data)
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to load messages'))
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    load()
+
+    subscription = chatApi.subscribeToMessages(id, message => {
+      setMessages(prev => [...prev, message])
+    })
+
+    return () => {
+      subscription?.unsubscribe()
+    }
+  }, [conversationId])
+
+  const sendMessage = async (senderId: string, content: string) => {
+    if (!conversationId) return
+    await chatApi.sendMessage({ conversation_id: conversationId, sender_id: senderId, content })
+  }
+
+  return { messages, loading, error, sendMessage }
+}

--- a/src/lib/supabase/chat.ts
+++ b/src/lib/supabase/chat.ts
@@ -1,0 +1,71 @@
+import supabaseClient from './supabaseClient'
+
+export type Conversation = {
+  id: string
+  name: string
+  avatar_url: string | null
+  type: 'personal' | 'business' | 'group'
+  last_message: string | null
+  last_message_at: string | null
+  unread_count: number
+}
+
+export type Message = {
+  id: string
+  conversation_id: string
+  sender_id: string
+  content: string
+  created_at: string
+  read: boolean
+}
+
+export async function getConversations(userId: string) {
+  const { data, error } = await supabaseClient
+    .from('user_conversations')
+    .select('*')
+    .eq('user_id', userId)
+    .order('last_message_at', { ascending: false })
+
+  if (error) throw error
+  return data as Conversation[]
+}
+
+export async function getMessages(conversationId: string) {
+  const { data, error } = await supabaseClient
+    .from('messages')
+    .select('*')
+    .eq('conversation_id', conversationId)
+    .order('created_at', { ascending: true })
+
+  if (error) throw error
+  return data as Message[]
+}
+
+export async function sendMessage(params: {
+  conversation_id: string
+  sender_id: string
+  content: string
+}) {
+  const { data, error } = await supabaseClient
+    .from('messages')
+    .insert(params)
+    .select()
+    .single()
+
+  if (error) throw error
+  return data as Message
+}
+
+export function subscribeToMessages(
+  conversationId: string,
+  callback: (message: Message) => void
+) {
+  return supabaseClient
+    .channel('messages')
+    .on(
+      'postgres_changes',
+      { event: 'INSERT', schema: 'public', table: 'messages', filter: `conversation_id=eq.${conversationId}` },
+      payload => callback(payload.new as Message)
+    )
+    .subscribe()
+}


### PR DESCRIPTION
## Summary
- add conversation and message utilities for Supabase
- create hooks for conversations and messages
- implement chat components (header, bubble, input, preview)
- build chat list page with filters and search
- add chat detail page with message sending and auto-scroll

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685e95e3c0b4832b8c5335a5540239e0