### PR TITLE
Update inbox UI with card layout

### DIFF
--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -6,6 +6,7 @@ import { ConversationPreview } from '@/components/chat/ConversationPreview'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { useState } from 'react'
 import { Button } from '@/components/ui/Button'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
 
 export default function InboxPage() {
   const { profile } = useSupabase()
@@ -27,45 +28,55 @@ export default function InboxPage() {
   })
 
   return (
-    <div className="space-y-6">
-      <h1 className="text-3xl font-bold text-primary">Chats</h1>
-      <div className="space-y-4">
-        <div className="relative">
-          <input
-            type="text"
-            placeholder="Search chats..."
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            className="w-full rounded-md border px-3 py-2 pl-8 text-sm"
-          />
-          <span className="absolute left-2 top-2.5 text-gray-400">🔍</span>
-        </div>
-        <div className="flex gap-2">
-          {(['all', 'unread', 'personal', 'business'] as const).map(f => (
-            <Button
-              key={f}
-              size="sm"
-              variant={filter === f ? 'default' : 'outline'}
-              onClick={() => setFilter(f)}
-            >
-              {f.charAt(0).toUpperCase() + f.slice(1)}
-            </Button>
-          ))}
-        </div>
+    <main className="container mx-auto px-4 py-8">
+      <div className="mx-auto max-w-2xl">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-3xl">Chats</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <div className="space-y-4">
+              <div className="relative">
+                <input
+                  type="text"
+                  placeholder="Search chats..."
+                  value={search}
+                  onChange={e => setSearch(e.target.value)}
+                  className="w-full rounded-md border px-3 py-2 pl-8 text-sm"
+                />
+                <span className="absolute left-2 top-2.5 text-gray-400">🔍</span>
+              </div>
+              <div className="flex gap-2 flex-wrap">
+                {(['all', 'unread', 'personal', 'business'] as const).map(f => (
+                  <Button
+                    key={f}
+                    size="sm"
+                    variant={filter === f ? 'default' : 'outline'}
+                    onClick={() => setFilter(f)}
+                  >
+                    {f.charAt(0).toUpperCase() + f.slice(1)}
+                  </Button>
+                ))}
+              </div>
+            </div>
+            {loading ? (
+              <div className="flex justify-center p-8">
+                <LoadingSpinner />
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {filtered.length === 0 ? (
+                  <p className="p-4 text-center text-sm text-gray-500">No chats found.</p>
+                ) : (
+                  filtered.map(c => (
+                    <ConversationPreview key={c.id} conversation={c} />
+                  ))
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
       </div>
-      {loading ? (
-        <div className="flex justify-center p-8">
-          <LoadingSpinner />
-        </div>
-      ) : (
-        <div className="flex flex-col gap-2">
-          {filtered.length === 0 ? (
-            <p className="p-4 text-center text-sm text-gray-500">No chats found.</p>
-          ) : (
-            filtered.map(c => <ConversationPreview key={c.id} conversation={c} />)
-          )}
-        </div>
-      )}
-    </div>
+    </main>
   )
 }

--- a/src/components/chat/ConversationPreview.tsx
+++ b/src/components/chat/ConversationPreview.tsx
@@ -13,22 +13,22 @@ export function ConversationPreview({ conversation }: Props) {
     <Link
       href={`/inbox/${conversation.id}`}
       className={cn(
-        'flex gap-4 rounded-md border p-3 transition-colors hover:bg-gray-50',
-        !conversation.unread_count ? '' : 'bg-blue-50 border-l-4 border-blue-400'
+        'flex gap-4 rounded-lg border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-800 p-4 shadow-sm transition-shadow hover:shadow-md',
+        conversation.unread_count > 0 && 'bg-blue-50 border-l-4 border-blue-400 dark:bg-neutral-800'
       )}
     >
       <Avatar src={conversation.avatar_url ?? undefined} alt={conversation.name} size={48} />
       <div className="flex min-w-0 flex-1 flex-col">
-        <div className="flex justify-between items-center">
-          <span className="font-medium truncate">{conversation.name}</span>
+        <div className="flex items-center justify-between">
+          <span className="truncate font-medium">{conversation.name}</span>
           {conversation.last_message_at && (
-            <span className="ml-2 text-xs text-gray-500 whitespace-nowrap">
+            <span className="ml-2 whitespace-nowrap text-xs text-gray-500">
               {formatDistanceToNow(new Date(conversation.last_message_at), { addSuffix: true })}
             </span>
           )}
         </div>
-        <div className="flex justify-between mt-1 items-start">
-          <span className="text-sm text-gray-600 truncate flex-1">{conversation.last_message}</span>
+        <div className="mt-1 flex items-start justify-between">
+          <span className="flex-1 truncate text-sm text-gray-600">{conversation.last_message}</span>
           {conversation.unread_count > 0 && (
             <span className="ml-2 flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs text-white">
               {conversation.unread_count}


### PR DESCRIPTION
## Summary
- restyle inbox page with card container
- adjust conversation previews to use card-like styling

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ea493a80c832b963bf3207e1493b2