### PR TITLE
Update inbox page layout

### DIFF
--- a/src/app/inbox/[id]/page.tsx
+++ b/src/app/inbox/[id]/page.tsx
@@ -49,7 +49,7 @@ export default function ChatDetailPage() {
   if (!conversation) return null
 
   return (
-    <div className="mx-auto flex h-[calc(100vh-10rem)] max-w-2xl flex-col rounded-md border shadow-sm">
+    <div className="mx-auto flex h-[calc(100vh-10rem)] max-w-3xl flex-col rounded-md border shadow-sm">
       <ChatHeader name={conversation.name} avatarUrl={conversation.avatar_url} />
       <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-3" id="messages">
         {messages.map(m => (

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -7,6 +7,7 @@ import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { useState } from 'react'
 import { Button } from '@/components/ui/Button'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
+import { Header } from '@/components/layout/Header'
 
 export default function InboxPage() {
   const { profile } = useSupabase()
@@ -28,8 +29,10 @@ export default function InboxPage() {
   })
 
   return (
-    <main className="container mx-auto px-4 py-8">
-      <div className="mx-auto max-w-2xl">
+    <div className="min-h-screen flex flex-col bg-background">
+      <Header />
+      <main className="container mx-auto flex-1 px-4 py-8">
+        <div className="mx-auto max-w-2xl">
         <Card>
           <CardHeader>
             <CardTitle className="text-3xl">Chats</CardTitle>
@@ -77,6 +80,10 @@ export default function InboxPage() {
           </CardContent>
         </Card>
       </div>
-    </main>
+      </main>
+      <footer className="mt-auto border-t bg-white py-6 text-center dark:bg-neutral-800 dark:border-neutral-700">
+        <p className="text-sm text-neutral-600 dark:text-neutral-300">&copy; 2025 CrowdCart Lite. All rights reserved.</p>
+      </footer>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- add global header and footer to inbox page to match app layout
- widen chat detail card for better messaging experience

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685eac45708c832b8383ae1dfd439ac5