### PR TITLE
Implement wallet funding via Paystack

### DIFF
--- a/src/app/api/fund-wallet/route.ts
+++ b/src/app/api/fund-wallet/route.ts
@@ -1,0 +1,35 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import axios from 'axios'
+
+export async function POST(request: Request) {
+  const { amount } = await request.json()
+  const supabase = createRouteHandlerClient({ cookies })
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const key = process.env.PAYSTACK_SECRET_KEY
+  if (!key) return NextResponse.json({ error: 'Payment unavailable' }, { status: 500 })
+  const reference = `DEP_${Date.now()}_${user.id}`
+  try {
+    const res = await axios.post('https://api.paystack.co/transaction/initialize', {
+      email: user.email,
+      amount: amount * 100,
+      reference,
+    }, {
+      headers: { Authorization: `Bearer ${key}` }
+    })
+    await supabase.from('transactions').insert({
+      user_id: user.id,
+      amount,
+      type: 'deposit',
+      status: 'pending',
+      reference_id: reference,
+    })
+    return NextResponse.json({ paymentUrl: res.data.data.authorization_url })
+  } catch (err: any) {
+    return NextResponse.json({ error: 'Failed to initiate payment' }, { status: 500 })
+  }
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
 import { User, Wallet, Settings, Bell } from 'lucide-react'
 import PayoutInfo from '@/components/profile/PayoutInfo'
+import { WalletCard } from '@/components/profile/WalletCard'
 import Image from 'next/image'
 import type { Session } from '@supabase/supabase-js' // Import Session type
 
@@ -130,20 +131,7 @@ export default async function ProfilePage() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <div className="space-y-4">
-                    <div>
-                      <p className="text-sm text-muted-foreground">Available Balance</p>
-                      <p className="text-3xl font-bold">${profile?.wallet_balance || '0.00'}</p>
-                    </div>
-                    <div>
-                      <p className="text-sm text-muted-foreground">Holds</p>
-                      <p className="text-xl font-semibold">${profile?.holds || '0.00'}</p>
-                    </div>
-                    <div className="flex gap-2 pt-2">
-                      <button className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white">Fund</button>
-                      <button className="rounded-lg bg-muted px-4 py-2 text-sm font-medium">Withdraw</button>
-                    </div>
-                  </div>
+                  <WalletCard balance={profile?.wallet_balance || 0} holds={profile?.holds || 0} />
                 </CardContent>
               </Card>
 

--- a/src/components/profile/FundWalletModal.tsx
+++ b/src/components/profile/FundWalletModal.tsx
@@ -1,0 +1,74 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/Button'
+import { X } from 'lucide-react'
+
+interface FundWalletModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function FundWalletModal({ isOpen, onClose }: FundWalletModalProps) {
+  const [amount, setAmount] = useState(0)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) setAmount(0)
+  }, [isOpen])
+
+  const handleSubmit = async () => {
+    if (amount <= 0) return
+    setLoading(true)
+    try {
+      const res = await fetch('/api/fund-wallet', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount })
+      })
+      const data = await res.json()
+      if (data.paymentUrl) {
+        window.location.href = data.paymentUrl
+      } else {
+        alert(data.error || 'Failed to initiate payment')
+      }
+    } catch (err) {
+      alert('Failed to initiate payment')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
+      <div
+        className="bg-white dark:bg-neutral-850 p-6 rounded-lg shadow-xl w-full max-w-sm"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">Fund Wallet</h2>
+          <button onClick={onClose} className="text-neutral-500 hover:text-neutral-700">
+            <X size={20} />
+          </button>
+        </div>
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(Number(e.target.value))}
+          placeholder="Amount"
+          className="w-full border rounded px-2 py-1 mb-4"
+        />
+        <Button className="w-full" onClick={handleSubmit} disabled={loading}>
+          {loading ? 'Processing...' : 'Proceed to Paystack'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/profile/WalletCard.tsx
+++ b/src/components/profile/WalletCard.tsx
@@ -1,0 +1,33 @@
+'use client'
+import { useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import { FundWalletModal } from './FundWalletModal'
+
+interface WalletCardProps {
+  balance: number
+  holds: number
+}
+
+export function WalletCard({ balance, holds }: WalletCardProps) {
+  const [showModal, setShowModal] = useState(false)
+  const openModal = () => setShowModal(true)
+  const closeModal = () => setShowModal(false)
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <p className="text-sm text-muted-foreground">Available Balance</p>
+        <p className="text-3xl font-bold">{balance ?? '0.00'}</p>
+      </div>
+      <div>
+        <p className="text-sm text-muted-foreground">Holds</p>
+        <p className="text-xl font-semibold">{holds ?? '0.00'}</p>
+      </div>
+      <div className="flex gap-2 pt-2">
+        <Button onClick={openModal}>Fund</Button>
+        <Button variant="secondary" disabled>Withdraw</Button>
+      </div>
+      <FundWalletModal isOpen={showModal} onClose={closeModal} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- allow wallet top-ups from profile
- add new `/api/fund-wallet` route that initializes Paystack transactions
- create `FundWalletModal` and `WalletCard` components
- integrate wallet funding UI on profile page

## Testing
- `npm install`
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ec9c48b54832b992927ca9bf2d453