### PR TITLE
Merge wallet and payout card with modal

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,7 +4,6 @@ import { createServerSupabaseClient } from '@/lib/supabase/server'
 import { redirect } from 'next/navigation'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
 import { User, Wallet, Settings, Bell } from 'lucide-react'
-import PayoutInfo from '@/components/profile/PayoutInfo'
 import { WalletCard } from '@/components/profile/WalletCard'
 import Image from 'next/image'
 import type { Session } from '@supabase/supabase-js' // Import Session type
@@ -131,19 +130,9 @@ export default async function ProfilePage() {
                   </CardTitle>
                 </CardHeader>
                 <CardContent>
-                  <WalletCard balance={profile?.wallet_balance || 0} holds={profile?.holds || 0} />
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center space-x-2">
-                    <Wallet className="h-5 w-5" />
-                    <span>Payout Info</span>
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <PayoutInfo
+                  <WalletCard
+                    balance={profile?.wallet_balance || 0}
+                    holds={profile?.holds || 0}
                     account_name={profile?.account_name}
                     account_number={profile?.account_number}
                     bank_name={profile?.bank_name}

--- a/src/components/profile/PayoutModal.tsx
+++ b/src/components/profile/PayoutModal.tsx
@@ -1,0 +1,89 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { Button } from '@/components/ui/Button'
+import { X } from 'lucide-react'
+
+interface PayoutModalProps {
+  isOpen: boolean
+  onClose: () => void
+  account_name?: string | null
+  account_number?: string | null
+  bank_name?: string | null
+  currency?: string | null
+}
+
+export function PayoutModal({ isOpen, onClose, account_name, account_number, bank_name, currency }: PayoutModalProps) {
+  const [form, setForm] = useState({
+    account_name: account_name || '',
+    account_number: account_number || '',
+    bank_name: bank_name || '',
+    currency: currency || 'NGN'
+  })
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      setForm({
+        account_name: account_name || '',
+        account_number: account_number || '',
+        bank_name: bank_name || '',
+        currency: currency || 'NGN'
+      })
+    }
+  }, [isOpen, account_name, account_number, bank_name, currency])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async () => {
+    setLoading(true)
+    try {
+      await fetch('/api/update-payout-info', {
+        method: 'POST',
+        body: JSON.stringify(form),
+        headers: { 'Content-Type': 'application/json' }
+      })
+      onClose()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
+      <div
+        className="bg-white dark:bg-neutral-850 p-6 rounded-lg shadow-xl w-full max-w-sm"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">Modify Payout</h2>
+          <button onClick={onClose} className="text-neutral-500 hover:text-neutral-700">
+            <X size={20} />
+          </button>
+        </div>
+        <div className="space-y-2">
+          <input name="account_name" value={form.account_name} onChange={handleChange} placeholder="Name" className="w-full border rounded px-2 py-1" />
+          <input name="account_number" value={form.account_number} onChange={handleChange} placeholder="Account Number" className="w-full border rounded px-2 py-1" />
+          <input name="bank_name" value={form.bank_name} onChange={handleChange} placeholder="Bank Name" className="w-full border rounded px-2 py-1" />
+          <select name="currency" value={form.currency} onChange={handleChange} className="w-full border rounded px-2 py-1">
+            <option value="NGN">NGN</option>
+            <option value="USD" disabled>USD</option>
+          </select>
+          <div className="flex gap-2 pt-1">
+            <Button onClick={handleSubmit} disabled={loading}>Save</Button>
+            <Button variant="secondary" onClick={onClose}>Cancel</Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/profile/WalletCard.tsx
+++ b/src/components/profile/WalletCard.tsx
@@ -2,16 +2,24 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/Button'
 import { FundWalletModal } from './FundWalletModal'
+import { PayoutModal } from './PayoutModal'
 
 interface WalletCardProps {
   balance: number
   holds: number
+  account_name?: string | null
+  account_number?: string | null
+  bank_name?: string | null
+  currency?: string | null
 }
 
-export function WalletCard({ balance, holds }: WalletCardProps) {
-  const [showModal, setShowModal] = useState(false)
-  const openModal = () => setShowModal(true)
-  const closeModal = () => setShowModal(false)
+export function WalletCard({ balance, holds, account_name, account_number, bank_name, currency }: WalletCardProps) {
+  const [showFundModal, setShowFundModal] = useState(false)
+  const [showPayoutModal, setShowPayoutModal] = useState(false)
+  const openFundModal = () => setShowFundModal(true)
+  const closeFundModal = () => setShowFundModal(false)
+  const openPayoutModal = () => setShowPayoutModal(true)
+  const closePayoutModal = () => setShowPayoutModal(false)
 
   return (
     <div className="space-y-4">
@@ -23,11 +31,20 @@ export function WalletCard({ balance, holds }: WalletCardProps) {
         <p className="text-sm text-muted-foreground">Holds</p>
         <p className="text-xl font-semibold">{holds ?? '0.00'}</p>
       </div>
-      <div className="flex gap-2 pt-2">
-        <Button onClick={openModal}>Fund</Button>
+      <div className="flex gap-2 pt-2 flex-wrap">
+        <Button onClick={openFundModal}>Fund</Button>
         <Button variant="secondary" disabled>Withdraw</Button>
+        <Button variant="secondary" onClick={openPayoutModal}>Modify Payout</Button>
       </div>
-      <FundWalletModal isOpen={showModal} onClose={closeModal} />
+      <FundWalletModal isOpen={showFundModal} onClose={closeFundModal} />
+      <PayoutModal
+        isOpen={showPayoutModal}
+        onClose={closePayoutModal}
+        account_name={account_name}
+        account_number={account_number}
+        bank_name={bank_name}
+        currency={currency}
+      />
     </div>
   )
 }

--- a/src/components/profile/__tests__/PayoutModal.test.tsx
+++ b/src/components/profile/__tests__/PayoutModal.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { PayoutModal } from '../PayoutModal'
+
+describe('PayoutModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('does not render when closed', () => {
+    render(<PayoutModal isOpen={false} onClose={jest.fn()} />)
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('submits payout details and closes', async () => {
+    const handleClose = jest.fn()
+    global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve({ success: true }) }) as any
+
+    render(
+      <PayoutModal
+        isOpen={true}
+        onClose={handleClose}
+        account_name="John"
+        account_number="123"
+        bank_name="ABC"
+        currency="NGN"
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('Name'), { target: { value: 'Jane' } })
+    fireEvent.click(screen.getByText('Save'))
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+    expect(global.fetch).toHaveBeenCalledWith('/api/update-payout-info', expect.objectContaining({ method: 'POST' }))
+    await waitFor(() => expect(handleClose).toHaveBeenCalled())
+  })
+
+  it('calls onClose when cancel clicked', () => {
+    const handleClose = jest.fn()
+    render(<PayoutModal isOpen={true} onClose={handleClose} />)
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(handleClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- unify wallet and payout info into a single card
- open a new modal to edit payout details
- wire wallet card to show payout modal
- add tests for payout modal behavior

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685f9327a3c0832ba25bc44a789a3c86