### PR TITLE
Implement Paystack wallet funding QA flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=public-anon-key
+SUPABASE_SERVICE_KEY=service-role-key
+PAYSTACK_SECRET_KEY=sk_test_xxx

--- a/README.md
+++ b/README.md
@@ -34,3 +34,11 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Wallet Funding QA Checklist
+
+- Initialize wallet with ₦100.
+- Fund with ₦500 using Paystack via `/api/deposit`.
+- Confirm final balance shows ₦600.
+- Re-trigger webhook with same reference and expect balance unchanged.
+

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -3,3 +3,4 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import "whatwg-fetch";

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,8 @@
         "jest-environment-jsdom": "^29.7.0",
         "ts-jest": "^29.1.2",
         "typescript": "^5",
-        "typescript-eslint": "^8.34.1"
+        "typescript-eslint": "^8.34.1",
+        "whatwg-fetch": "^3.6.20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -13209,6 +13210,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "^29.1.2",
     "typescript": "^5",
-    "typescript-eslint": "^8.34.1"
+    "typescript-eslint": "^8.34.1",
+    "whatwg-fetch": "^3.6.20"
   }
 }

--- a/pages/api/__tests__/deposit.spec.ts
+++ b/pages/api/__tests__/deposit.spec.ts
@@ -1,0 +1,15 @@
+import { POST } from "../../../src/app/api/deposit/route"
+import axios from 'axios'
+
+jest.mock('axios')
+
+const mocked = axios as jest.Mocked<typeof axios>
+
+describe('deposit api', () => {
+  it('calls paystack initialize', async () => {
+    mocked.post.mockResolvedValue({ data: { data: { authorization_url: 'http://pay' } } })
+    const req = new Request('http://test', { method: 'POST', body: JSON.stringify({ email: 'a@test.com', amount: 100 }) })
+    await POST(req as any)
+    expect(mocked.post).toHaveBeenCalled()
+  })
+})

--- a/pages/api/paystack-webhook.ts
+++ b/pages/api/paystack-webhook.ts
@@ -1,0 +1,36 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import crypto from 'crypto'
+import axios from 'axios'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_KEY!
+)
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
+
+  const signature = req.headers['x-paystack-signature'] as string | undefined
+  const key = process.env.PAYSTACK_SECRET_KEY
+  if (!signature || !key) return res.status(400).json({ error: 'Invalid signature' })
+
+  const hash = crypto.createHmac('sha512', key).update(JSON.stringify(req.body)).digest('hex')
+  if (hash !== signature) return res.status(400).json({ error: 'Invalid signature' })
+
+  const reference = req.body.data?.reference
+  try {
+    const verify = await axios.get(`https://api.paystack.co/transaction/verify/${reference}`, {
+      headers: { Authorization: `Bearer ${key}` }
+    })
+    const data = verify.data.data
+    if (data.status !== 'success') return res.status(200).json({})
+    const email = data.customer.email
+    const amount = data.amount
+
+    await supabase.rpc('wallet_deposit', { email, amount })
+    return res.status(200).json({})
+  } catch (e) {
+    return res.status(500).json({ error: 'Webhook failed' })
+  }
+}

--- a/pages/deposit.tsx
+++ b/pages/deposit.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+
+export default function DepositPage() {
+  const [email, setEmail] = useState('')
+  const [amount, setAmount] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [pending, setPending] = useState(false)
+  const [reference, setReference] = useState('')
+
+  async function handlePay() {
+    setLoading(true)
+    const res = await fetch('/api/deposit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, amount: Number(amount) * 100 })
+    })
+    const data = await res.json()
+    if (data.authorization_url) {
+      setReference(data.reference)
+      window.location.href = data.authorization_url
+    } else {
+      alert(data.error || 'Error')
+    }
+    setLoading(false)
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      {pending ? (
+        <p>Pending confirmation...</p>
+      ) : (
+        <>
+          <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" className="border p-2" />
+          <input value={amount} onChange={e => setAmount(e.target.value)} placeholder="Amount" className="border p-2" />
+          <button onClick={handlePay} disabled={loading}>Pay</button>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/app/api/deposit/route.ts
+++ b/src/app/api/deposit/route.ts
@@ -1,0 +1,26 @@
+import axios from 'axios'
+
+export async function POST(request: Request) {
+  const { email, amount } = await request.json()
+  if (!email || !amount) {
+    return new Response(JSON.stringify({ error: 'Invalid payload' }), { status: 400 })
+  }
+  const key = process.env.PAYSTACK_SECRET_KEY
+  if (!key) {
+    return new Response(JSON.stringify({ error: 'Payment unavailable' }), { status: 500 })
+  }
+  try {
+    const reference = `DEP_${Date.now()}`
+    const res = await axios.post('https://api.paystack.co/transaction/initialize', {
+      email,
+      amount,
+      reference
+    }, { headers: { Authorization: `Bearer ${key}` } })
+    return new Response(JSON.stringify({ authorization_url: res.data.data.authorization_url, reference }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    })
+  } catch (err: any) {
+    return new Response(JSON.stringify({ error: 'Failed to initiate payment' }), { status: 500 })
+  }
+}

--- a/tests/integration/deposit.e2e.ts
+++ b/tests/integration/deposit.e2e.ts
@@ -1,0 +1,19 @@
+import { POST as deposit } from '../../src/app/api/deposit/route'
+import webhook from '../../pages/api/paystack-webhook'
+
+jest.mock('axios', () => ({
+  default: {
+    post: jest.fn().mockResolvedValue({ data: { data: { authorization_url: 'http://pay' } } }),
+    get: jest.fn().mockResolvedValue({ data: { data: { status: 'success', customer: { email: 'a@test.com' }, amount: 100 } } })
+  }
+}))
+
+describe('deposit flow', () => {
+  it('runs webhook after deposit', async () => {
+    await deposit(new Request('http://test', { method: 'POST', body: JSON.stringify({ email: 'a@test.com', amount: 100 }) }) as any)
+    const req: any = { method: 'POST', body: { data: { reference: 'ref', customer: { email: 'a@test.com' }, amount: 100 } }, headers: { 'x-paystack-signature': 'sig' } }
+    const resMock: any = { status: jest.fn().mockReturnThis(), json: jest.fn() }
+    await webhook(req, resMock)
+    expect(resMock.status).toHaveBeenCalled()
+  })
+})

--- a/wallet_txn.sql
+++ b/wallet_txn.sql
@@ -1,0 +1,16 @@
+-- Wallet transaction log for idempotency
+CREATE TABLE IF NOT EXISTS public.wallet_txn (
+  id uuid DEFAULT uuid_generate_v4() PRIMARY KEY,
+  email text NOT NULL,
+  reference text UNIQUE NOT NULL,
+  amount numeric NOT NULL,
+  created_at timestamp with time zone DEFAULT timezone('utc', now())
+);
+
+-- optional index
+CREATE INDEX IF NOT EXISTS wallet_txn_email_idx ON public.wallet_txn(email);
+
+-- RLS
+ALTER TABLE public.wallet_txn ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow read" ON public.wallet_txn FOR SELECT USING (true);
+CREATE POLICY "Service insert" ON public.wallet_txn FOR INSERT WITH CHECK (auth.role() = 'service_role');


### PR DESCRIPTION
## Summary
- create Paystack webhook API endpoint
- expose deposit initialization API
- add simple deposit page
- add wallet deposit tests and integration test skeleton
- document Wallet Funding QA checklist
- provide env template and SQL for wallet transactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685fa77fa494832b9be51e4e8030e6c9