### PR TITLE
Fix Paystack deposit parameter bug

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -137,6 +137,7 @@ export default async function ProfilePage() {
                     account_number={profile?.account_number}
                     bank_name={profile?.bank_name}
                     currency={profile?.currency}
+                    email={session.user.email || ''}
                   />
                 </CardContent>
               </Card>

--- a/src/components/DepositForm.tsx
+++ b/src/components/DepositForm.tsx
@@ -1,7 +1,11 @@
 'use client'
 import { useState } from 'react'
 
-export default function DepositForm() {
+interface DepositFormProps {
+  email: string
+}
+
+export default function DepositForm({ email }: DepositFormProps) {
   const [amount, setAmount] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -17,7 +21,7 @@ export default function DepositForm() {
       const res = await fetch('/api/deposit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: '', amount: value }),
+        body: JSON.stringify({ email, amount: value }),
       })
       const data = await res.json()
       if (res.ok && data.authorization_url) {

--- a/src/components/__tests__/DepositForm.test.tsx
+++ b/src/components/__tests__/DepositForm.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import DepositForm from '../DepositForm'
+
+describe('DepositForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ authorization_url: 'http://pay' }) }) as any
+  })
+
+  it('submits valid amount', async () => {
+    render(<DepositForm email="test@example.com" />)
+    fireEvent.change(screen.getByPlaceholderText('Amount'), { target: { value: '200' } })
+    fireEvent.click(screen.getByRole('button', { name: /proceed to paystack/i }))
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+    const args = (global.fetch as jest.Mock).mock.calls[0]
+    expect(args[0]).toBe('/api/deposit')
+    const body = JSON.parse(args[1].body)
+    expect(body).toEqual({ email: 'test@example.com', amount: 200 })
+  })
+
+  it('rejects invalid amount', async () => {
+    const alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {})
+    render(<DepositForm email="test@example.com" />)
+    fireEvent.change(screen.getByPlaceholderText('Amount'), { target: { value: '50' } })
+    fireEvent.click(screen.getByRole('button', { name: /proceed to paystack/i }))
+    expect(alertSpy).toHaveBeenCalledWith('Minimum amount is ₦100')
+    expect(global.fetch).not.toHaveBeenCalled()
+    alertSpy.mockRestore()
+  })
+})

--- a/src/components/profile/FundWalletModal.tsx
+++ b/src/components/profile/FundWalletModal.tsx
@@ -5,9 +5,10 @@ import DepositForm from '../DepositForm'
 interface FundWalletModalProps {
   isOpen: boolean
   onClose: () => void
+  email: string
 }
 
-export function FundWalletModal({ isOpen, onClose }: FundWalletModalProps) {
+export function FundWalletModal({ isOpen, onClose, email }: FundWalletModalProps) {
 
   if (!isOpen) return null
 
@@ -29,7 +30,7 @@ export function FundWalletModal({ isOpen, onClose }: FundWalletModalProps) {
             <X size={20} />
           </button>
         </div>
-        <DepositForm />
+        <DepositForm email={email} />
       </div>
     </div>
   )

--- a/src/components/profile/WalletCard.tsx
+++ b/src/components/profile/WalletCard.tsx
@@ -11,9 +11,10 @@ interface WalletCardProps {
   account_number?: string | null
   bank_name?: string | null
   currency?: string | null
+  email: string
 }
 
-export function WalletCard({ balance, holds, account_name, account_number, bank_name, currency }: WalletCardProps) {
+export function WalletCard({ balance, holds, account_name, account_number, bank_name, currency, email }: WalletCardProps) {
   const [showFundModal, setShowFundModal] = useState(false)
   const [showPayoutModal, setShowPayoutModal] = useState(false)
   const openFundModal = () => setShowFundModal(true)
@@ -36,7 +37,7 @@ export function WalletCard({ balance, holds, account_name, account_number, bank_
         <Button variant="secondary" disabled>Withdraw</Button>
         <Button variant="secondary" onClick={openPayoutModal}>Modify Payout</Button>
       </div>
-      <FundWalletModal isOpen={showFundModal} onClose={closeFundModal} />
+      <FundWalletModal isOpen={showFundModal} onClose={closeFundModal} email={email} />
       <PayoutModal
         isOpen={showPayoutModal}
         onClose={closePayoutModal}


### PR DESCRIPTION
## Summary
- pass user email into Paystack deposit form
- wire the email through FundWalletModal and WalletCard
- ensure profile page supplies the email
- verify Paystack webhook only checks credentials after signature verification
- add unit tests for DepositForm

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686085577c5c832b9b6832faea426137