### PR TITLE
Validate amount in payment APIs

### DIFF
--- a/src/app/api/__tests__/deposit.test.ts
+++ b/src/app/api/__tests__/deposit.test.ts
@@ -20,4 +20,14 @@ describe('deposit API', () => {
     const res = await POST(req as any)
     expect(res.status).toBe(500)
   })
+
+  it('rejects invalid amount', async () => {
+    const req = new Request('http://localhost/api/deposit', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'a@test.com', amount: 50 }),
+      headers: { 'Content-Type': 'application/json' }
+    })
+    const res = await POST(req as any)
+    expect(res.status).toBe(400)
+  })
 })

--- a/src/app/api/__tests__/fund-wallet.test.ts
+++ b/src/app/api/__tests__/fund-wallet.test.ts
@@ -1,0 +1,20 @@
+/** @jest-environment node */
+import { POST } from '../fund-wallet/route'
+
+jest.mock('@supabase/auth-helpers-nextjs', () => ({
+  createRouteHandlerClient: jest.fn(() => ({})),
+}))
+
+jest.mock('axios')
+
+describe('fund-wallet API', () => {
+  it('rejects invalid amount', async () => {
+    const req = new Request('http://localhost/api/fund-wallet', {
+      method: 'POST',
+      body: JSON.stringify({ amount: 50 }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req as any)
+    expect(res.status).toBe(400)
+  })
+})

--- a/src/app/api/__tests__/group-payment.test.ts
+++ b/src/app/api/__tests__/group-payment.test.ts
@@ -1,0 +1,20 @@
+/** @jest-environment node */
+import { POST } from '../group-payment/route'
+
+jest.mock('@supabase/auth-helpers-nextjs', () => ({
+  createRouteHandlerClient: jest.fn(() => ({})),
+}))
+
+jest.mock('axios')
+
+describe('group-payment API', () => {
+  it('rejects invalid amount', async () => {
+    const req = new Request('http://localhost/api/group-payment', {
+      method: 'POST',
+      body: JSON.stringify({ amount: 20 }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req as any)
+    expect(res.status).toBe(400)
+  })
+})

--- a/src/app/api/deposit/route.ts
+++ b/src/app/api/deposit/route.ts
@@ -3,7 +3,8 @@ import axios from 'axios'
 
 export async function POST(req: Request) {
   const { email, amount } = await req.json()
-  if (!email || !amount || amount < 100) {
+  const value = Number(amount)
+  if (!email || isNaN(value) || value < 100) {
     return NextResponse.json({ error: 'Invalid parameters' }, { status: 400 })
   }
   const key = process.env.PAYSTACK_SECRET_KEY
@@ -16,7 +17,7 @@ export async function POST(req: Request) {
       'https://api.paystack.co/transaction/initialize',
       {
         email,
-        amount: amount * 100,
+        amount: value * 100,
         callback_url: callbackUrl,
       },
       { headers: { Authorization: `Bearer ${key}` } }

--- a/src/app/api/fund-wallet/route.ts
+++ b/src/app/api/fund-wallet/route.ts
@@ -5,6 +5,10 @@ import axios from 'axios'
 
 export async function POST(request: Request) {
   const { amount } = await request.json()
+  const value = Number(amount)
+  if (isNaN(value) || value < 100) {
+    return NextResponse.json({ error: 'Invalid amount' }, { status: 400 })
+  }
   const supabase = createRouteHandlerClient({ cookies })
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) {
@@ -16,14 +20,14 @@ export async function POST(request: Request) {
   try {
     const res = await axios.post('https://api.paystack.co/transaction/initialize', {
       email: user.email,
-      amount: amount * 100,
+      amount: value * 100,
       reference,
     }, {
       headers: { Authorization: `Bearer ${key}` }
     })
     await supabase.from('transactions').insert({
       user_id: user.id,
-      amount,
+      amount: value,
       type: 'deposit',
       status: 'pending',
       reference_id: reference,


### PR DESCRIPTION
## Summary
- validate numeric amount in payment routes
- handle invalid amounts with HTTP 400
- add jest tests for new validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868e601c2b0832bb60efcbc2ddf75c4