### PR TITLE
Fix sidebar overlapping header

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Sidebar } from '@/components/layout/Sidebar'
+import { Header } from '@/components/layout/Header'
 
 export default function DashboardLayout({
   children,
@@ -8,11 +9,14 @@ export default function DashboardLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="flex min-h-screen">
-      <Sidebar />
-      <main className="flex-1 ml-16 transition-all duration-300">
-        {children}
-      </main>
+    <div className="flex flex-col min-h-screen">
+      <Header />
+      <div className="flex flex-1">
+        <Sidebar />
+        <main className="flex-1 ml-16 transition-all duration-300">
+          {children}
+        </main>
+      </div>
     </div>
   )
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,7 +2,6 @@ export const dynamic = 'force-dynamic'
 
 import { Suspense } from 'react'
 import { ShoppingBag, Search, Filter, Plus, Users, AlertCircle, LayoutGrid } from 'lucide-react' // Added LayoutGrid
-import { Header } from '@/components/layout/Header'
 import { RoleToggle } from '@/components/dashboard/RoleToggle'
 import { ProductCard } from '@/components/products/ProductCard'
 import { getUserProfile } from '@/lib/supabase/server'
@@ -325,8 +324,7 @@ async function DashboardContent({ searchParams }: { searchParams?: any }) {
 // Modify DashboardPage to pass searchParams to DashboardContent
 export default async function DashboardPage({ searchParams }: { searchParams?: any }) {
 	return (
-		<div className="min-h-screen bg-[#F0F4F7] flex flex-col dark:bg-neutral-900">
-			<Header /> {/* Header might need dark mode styles too */}
+                <div className="min-h-screen bg-[#F0F4F7] flex flex-col dark:bg-neutral-900">
 			<ErrorBoundary>
 				<Suspense
 					fallback={

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -162,7 +162,8 @@ export function Sidebar() {
   return (
     <aside
       className={cn(
-        'fixed left-0 top-0 z-40 h-screen transition-all duration-300 ease-in-out',
+        'fixed left-0 top-16 z-40 transition-all duration-300 ease-in-out',
+        'h-[calc(100vh-4rem)]',
         'bg-white border-r dark:bg-gray-900 dark:border-gray-800',
         'transform will-change-transform',
         isExpanded ? 'w-64' : 'w-16',


### PR DESCRIPTION
## Summary
- place header inside dashboard layout so it's not pushed by sidebar
- keep sidebar below header
- clean up dashboard page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6868ebc35728832bab8b01cc8590a32d