### PR TITLE
UI-101 Add border between header and sidebar

### DIFF
--- a/Milestones.md
+++ b/Milestones.md
@@ -1,0 +1,4 @@
+# Project Milestones
+
+## MILESTONE-1
+- **UI-101** - Add dividing line between Header and Sidebar (status: draft)

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -164,7 +164,8 @@ export function Sidebar() {
       className={cn(
         'fixed left-0 top-16 z-40 transition-all duration-300 ease-in-out',
         'h-[calc(100vh-4rem)]',
-        'bg-white border-r dark:bg-gray-900 dark:border-gray-800',
+        'bg-white border-r border-t dark:bg-gray-900',
+        'dark:border-r-gray-800 dark:border-t-neutral-700',
         'transform will-change-transform',
         isExpanded ? 'w-64' : 'w-16',
         !isExpanded && '-translate-x-0'

--- a/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { Sidebar } from '../Sidebar';
+
+// Mock next/navigation to provide a path for usePathname
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/dashboard',
+}));
+
+jest.mock('@/contexts/SupabaseProvider', () => ({
+  useSupabase: () => ({ profile: { id: '1' } })
+}));
+
+jest.mock('@/lib/supabase/notifications', () => ({
+  getUnreadNotificationCount: jest.fn().mockResolvedValue(0)
+}));
+
+// Mock next/link to simply render anchors during test
+jest.mock('next/link', () => {
+  return ({ children, href }: any) => <a href={href}>{children}</a>;
+});
+
+describe('Sidebar component', () => {
+  it('applies top border classes', () => {
+    render(<Sidebar />);
+    const aside = screen.getByLabelText('Main navigation');
+    expect(aside.className).toContain('border-t');
+    expect(aside.className).toContain('dark:border-t-neutral-700');
+  });
+});

--- a/subagents_report/UI-101_accountable.md
+++ b/subagents_report/UI-101_accountable.md
@@ -1,0 +1,3 @@
+# UI-101 Accountable Report
+
+The sidebar top border was implemented and tested. Milestone and test outcomes recorded.

--- a/subagents_report/UI-101_consulted.md
+++ b/subagents_report/UI-101_consulted.md
@@ -1,0 +1,3 @@
+# UI-101 Consulted Report
+
+No additional consultations were required for this minor UI update.

--- a/subagents_report/UI-101_informed.md
+++ b/subagents_report/UI-101_informed.md
@@ -1,0 +1,3 @@
+# UI-101 Informed Report
+
+Stakeholders have been notified of the draft status via this report.

--- a/subagents_report/UI-101_responsible.md
+++ b/subagents_report/UI-101_responsible.md
@@ -1,0 +1,3 @@
+# UI-101 Responsible Report
+
+Implemented border styles in `Sidebar.tsx`, added unit test, and updated milestone.

--- a/subagents_report/UI-101_unit.md
+++ b/subagents_report/UI-101_unit.md
@@ -1,0 +1,3 @@
+# UI-101 Unit Test Report
+
+All Jest unit tests passed including the new sidebar border check.


### PR DESCRIPTION
## Summary
- show a top border on the sidebar so it separates from the header
- test that sidebar has the correct border classes
- document the milestone entry
- log reports for the UI-101 task

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868fa60c8b8832bbcffc994fef23c7c