### PR TITLE
UI-103 sidebar descriptive text

### DIFF
--- a/Milestones.md
+++ b/Milestones.md
@@ -3,3 +3,4 @@
 ## MILESTONE-1
 - **UI-101** - Add dividing line between Header and Sidebar (status: draft)
 - **UI-102** - Add buyer FAB to suggest new product (status: draft)
+- **UI-103** - Add descriptive labels below sidebar icons (status: draft)

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -18,12 +18,27 @@ import { Tooltip } from '@/components/ui/tooltip'
 import { getUnreadNotificationCount } from '@/lib/supabase/notifications'; // NEW IMPORT
 
 const mainNavItems = [
-  { name: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
-  { name: 'Inbox', href: '/inbox', icon: Mail }, // Added Inbox item
+  {
+    name: 'Dashboard',
+    href: '/dashboard',
+    icon: LayoutDashboard,
+    description: 'View dashboard',
+  },
+  {
+    name: 'Inbox',
+    href: '/inbox',
+    icon: Mail, // Added Inbox item
+    description: 'Check messages',
+  },
 ]
 
 const bottomNavItems = [
-  { name: 'Profile', href: '/profile', icon: UserCircle },
+  {
+    name: 'Profile',
+    href: '/profile',
+    icon: UserCircle,
+    description: 'Manage profile',
+  },
 ]
 
 const SWIPE_THRESHOLD = 50 // minimum distance for swipe
@@ -88,10 +103,17 @@ export function Sidebar() {
   }, [])
 
   const renderNavItem = useCallback(
-    // ({ name, href, icon: Icon }: typeof mainNavItems[0]) => { // Original typing
-    // Using a more generic type for item to satisfy both main and bottom nav items if their types differ slightly
-    // For now, assuming they share: name: string, href: string, icon: React.ElementType
-    ({ name, href, icon: Icon }: { name: string; href: string; icon: React.ElementType }) => {
+    ({
+      name,
+      href,
+      icon: Icon,
+      description,
+    }: {
+      name: string
+      href: string
+      icon: React.ElementType
+      description: string
+    }) => {
       const isActive = pathname.startsWith(href);
 
       // Dynamic condition for showing the notification badge
@@ -109,7 +131,7 @@ export function Sidebar() {
           )}
           aria-current={isActive ? 'page' : undefined}
         >
-          <div className="relative flex-shrink-0"> {/* Wrapper for icon and potential badge on icon */}
+          <div className="relative flex-shrink-0 flex flex-col items-center"> {/* Wrapper for icon and potential badge on icon */}
             <Icon
               className={cn(
                 'h-5 w-5 flex-shrink-0 transition-colors duration-150', // Removed mr-3 from here
@@ -120,8 +142,11 @@ export function Sidebar() {
               aria-hidden="true"
             />
             {/* Badge on icon (for collapsed state, more subtle) */}
-            {showNotificationBadge && !isExpanded && ( // Use showNotificationBadge
+            {showNotificationBadge && !isExpanded && (
               <span className="absolute -top-0.5 -right-0.5 block h-2 w-2 rounded-full bg-red-500 ring-1 ring-white dark:ring-gray-900" />
+            )}
+            {isExpanded && (
+              <span className="text-xs text-neutral-500 mt-1">{description}</span>
             )}
           </div>
 

--- a/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/src/components/layout/__tests__/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Sidebar } from '../Sidebar';
 
 // Mock next/navigation to provide a path for usePathname
@@ -25,5 +25,12 @@ describe('Sidebar component', () => {
     const aside = screen.getByLabelText('Main navigation');
     expect(aside.className).toContain('border-t');
     expect(aside.className).toContain('dark:border-t-neutral-700');
+  });
+
+  it('shows description text when expanded', async () => {
+    render(<Sidebar />);
+    const aside = screen.getByLabelText('Main navigation');
+    fireEvent.mouseEnter(aside);
+    expect(await screen.findByText('View dashboard')).toBeInTheDocument();
   });
 });

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -1,0 +1,3 @@
+# UI-103 Accountable Report
+
+2025-07-05 - Confirmed descriptions render below sidebar icons and updated Milestones.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -1,0 +1,3 @@
+# UI-103 Consulted Report
+
+2025-07-05 - No consultations were necessary for this UI update.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -1,0 +1,3 @@
+# UI-103 Informed Report
+
+2025-07-05 - Stakeholders informed about the sidebar label enhancement.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -1,0 +1,3 @@
+# UI-103 Responsible Report
+
+2025-07-05 - Added description field, updated Sidebar UI, tests, and milestone entry.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -1,0 +1,3 @@
+# UI-103 Unit Test Report
+
+2025-07-05 - Added test to verify description text appears when sidebar is expanded.


### PR DESCRIPTION
## Summary
- show small descriptive text below sidebar icons when expanded
- add unit test for the description rendering
- record milestone entry and update subagent reports

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6869a58ef978832b9cf6d8486b14dc97