### PR TITLE
Fix duplicate price field

### DIFF
--- a/src/lib/supabase/products.ts
+++ b/src/lib/supabase/products.ts
@@ -72,7 +72,6 @@ export async function createProduct(product: {
   delivery_time: string | null;
 
   // Parameters for automatic group creation
-  price: number; // Added to function parameters, expected from AddProductModal
   createTimedGroup: boolean;
   groupSize: number;
   countdownSecs: number | null;


### PR DESCRIPTION
## Summary
- remove duplicate `price` field from the `createProduct` arguments

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686be6f27cd8832b916c057d2224a9c0