### PR TITLE
UI-109: add logout button to sidebar

### DIFF
--- a/Milestones.md
+++ b/Milestones.md
@@ -9,6 +9,7 @@
 - **UI-106** - Add captions and truncate sidebar descriptions (status: draft)
 - **UI-107** - Align sidebar icons vertically with descriptions (status: draft)
 - **UI-108** - Add divider above bottom sidebar icons (status: draft)
+- **UI-109** - Add Logout icon to sidebar bottom navigation (status: draft)
 
 ## MILESTONE-2 – Core Feature Enhancements
 - **Start:** 2023-10-27

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -18,5 +18,6 @@ end note
 note bottom of Sidebar
   Divider separates bottom navigation icons
   from the main navigation links
+  Logout button appears below the Profile icon
 end note
 @enduml

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRight,
   Mail, // Added for Inbox
   Settings, // Added for Settings
+  Power,
 } from 'lucide-react'
 import { useState, useRef, useCallback, useEffect } from 'react' // Ensure useEffect, useState are imported
 import { useSupabase } from '@/contexts/SupabaseProvider'
@@ -40,6 +41,12 @@ const bottomNavItems = [
     icon: UserCircle,
     description: 'Details about your account and wallet services.',
   },
+  {
+    name: 'Logout',
+    href: '#logout',
+    icon: Power,
+    description: '',
+  },
 ]
 
 const SWIPE_THRESHOLD = 50 // minimum distance for swipe
@@ -47,7 +54,7 @@ const SWIPE_TIMEOUT = 300 // maximum time for swipe
 
 export function Sidebar() {
   const pathname = usePathname()
-  const { profile } = useSupabase()
+  const { profile, signOut } = useSupabase()
   const [isExpanded, setIsExpanded] = useState(false)
   const touchStartRef = useRef({ x: 0, y: 0, time: 0 })
 
@@ -120,15 +127,27 @@ export function Sidebar() {
       // Dynamic condition for showing the notification badge
       const showNotificationBadge = name === 'Inbox' && unreadCount > 0;
 
+      const handleClick = async (
+        e: React.MouseEvent<HTMLAnchorElement, MouseEvent>
+      ) => {
+        if (name === 'Logout') {
+          e.preventDefault();
+          await signOut();
+        }
+      };
+
       const linkContent = (
         <Link
           href={href}
+          onClick={handleClick}
           className={cn(
             'group relative flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-all duration-150',
             'hover:bg-gray-50 dark:hover:bg-gray-800',
             isActive
               ? 'bg-gray-100 text-primary dark:bg-gray-800 dark:text-primary-light'
-              : 'text-gray-700 hover:text-primary dark:text-gray-300 dark:hover:text-primary-light'
+              : name === 'Logout'
+                ? 'text-red-500 hover:text-red-600'
+                : 'text-gray-700 hover:text-primary dark:text-gray-300 dark:hover:text-primary-light'
           )}
           aria-current={isActive ? 'page' : undefined}
         >
@@ -136,9 +155,11 @@ export function Sidebar() {
             <Icon
               className={cn(
                 'h-5 w-5 flex-shrink-0 transition-colors duration-150',
-                isActive
-                  ? 'text-primary dark:text-primary-light'
-                  : 'text-gray-400 group-hover:text-primary dark:text-gray-400 dark:group-hover:text-primary-light'
+                name === 'Logout'
+                  ? 'text-red-500 group-hover:text-red-600'
+                  : isActive
+                      ? 'text-primary dark:text-primary-light'
+                      : 'text-gray-400 group-hover:text-primary dark:text-gray-400 dark:group-hover:text-primary-light'
               )}
               aria-hidden="true"
             />
@@ -149,7 +170,9 @@ export function Sidebar() {
           {isExpanded && (
             <div className="ml-3 flex flex-col w-full overflow-hidden">
               <span className="text-sm font-semibold">{name}</span>
-              <span className="text-xs text-neutral-500 line-clamp-2">{description}</span>
+              {name !== 'Logout' && (
+                <span className="text-xs text-neutral-500 line-clamp-2">{description}</span>
+              )}
             </div>
           )}
           {isExpanded &&
@@ -171,7 +194,7 @@ export function Sidebar() {
         </div>
       )
     },
-    [pathname, isExpanded, unreadCount] // ADD unreadCount to dependency array
+    [pathname, isExpanded, unreadCount, signOut]
   )
 
   return (

--- a/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/src/components/layout/__tests__/Sidebar.test.tsx
@@ -6,8 +6,9 @@ jest.mock('next/navigation', () => ({
   usePathname: () => '/dashboard',
 }));
 
+const signOutMock = jest.fn();
 jest.mock('@/contexts/SupabaseProvider', () => ({
-  useSupabase: () => ({ profile: { id: '1' } })
+  useSupabase: () => ({ profile: { id: '1' }, signOut: signOutMock })
 }));
 
 jest.mock('@/lib/supabase/notifications', () => ({
@@ -66,5 +67,19 @@ describe('Sidebar component', () => {
 
     fireEvent.mouseLeave(aside);
     expect(within(aside).queryByText('Dashboard')).toBeNull();
+  });
+
+  it('renders Logout without description and triggers signOut', async () => {
+    render(<Sidebar />);
+    const aside = screen.getByLabelText('Main navigation');
+    fireEvent.mouseEnter(aside);
+
+    const logout = await screen.findByText('Logout');
+    expect(logout).toBeInTheDocument();
+    const desc = within(logout.closest('div')!).queryByText(/Details about/);
+    expect(desc).toBeNull();
+
+    fireEvent.click(logout);
+    expect(signOutMock).toHaveBeenCalled();
   });
 });

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -6,3 +6,4 @@
 2025-07-07 - Verified captions and truncated descriptions for UI-106.
 2025-07-08 - Confirmed icons vertically centered with descriptions for UI-107.
 2025-07-09 - Confirmed divider above bottom sidebar icons for UI-108.
+2025-07-10 - Confirmed logout icon added to bottom navigation for UI-109.

--- a/subagents_report/architectureDiagram.md
+++ b/subagents_report/architectureDiagram.md
@@ -2,3 +2,4 @@
 
 2025-07-08 - Updated diagram note to reflect icon alignment for UI-107.
 2025-07-09 - Added note about bottom navigation separation for UI-108.
+2025-07-10 - Added logout button note in sidebar for UI-109.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -6,3 +6,4 @@
 2025-07-07 - No consultations were necessary for UI-106.
 2025-07-08 - No consultations were necessary for UI-107.
 2025-07-09 - No consultations were necessary for UI-108.
+2025-07-10 - No consultations were necessary for UI-109.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -6,3 +6,4 @@
 2025-07-07 - Stakeholders notified about caption and truncation changes for UI-106.
 2025-07-08 - Stakeholders notified about icon alignment update for UI-107.
 2025-07-09 - Stakeholders informed about sidebar divider for UI-108.
+2025-07-10 - Stakeholders informed about logout button in sidebar for UI-109.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -6,3 +6,4 @@
 2025-07-07 - Implemented captions with truncated descriptions and updated tests for UI-106.
 2025-07-08 - Updated sidebar to center icons and added tests for UI-107.
 2025-07-09 - Added divider above bottom navigation with tests and docs for UI-108.
+2025-07-10 - Added logout icon with tests and docs for UI-109.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -6,3 +6,4 @@
 2025-07-07 - Added tests for caption rendering and line clamp for UI-106.
 2025-07-08 - Added test for vertical centering class on navigation links for UI-107.
 2025-07-09 - Added test to verify divider classes above bottom nav for UI-108.
+2025-07-10 - Added test to verify logout icon renders without description for UI-109.

--- a/task_definition_UI-109.json
+++ b/task_definition_UI-109.json
@@ -1,0 +1,62 @@
+{
+  "taskId": "UI-109",
+  "title": "Add Logout Icon to Sidebar Bottom Navigation",
+  "taskType": "update",
+  "updateType": "ui-patch",
+  "featureStage": "existing",
+  "scope": { "frontend": true },
+  "priority": "P1",
+  "status": "draft",
+  "description": "Show a red power button icon labelled \"Logout\" beneath the Profile item in the sidebar. The logout button has only a caption (no description) and triggers `signOut` when clicked.",
+  "acceptanceCriteria": [
+    "Sidebar displays a power icon below the Profile item when collapsed or expanded",
+    "Icon uses red styling (`text-red-500` with darker hover state)",
+    "When sidebar is expanded, only the caption \"Logout\" is visible (no description text)",
+    "Clicking the Logout item calls the `signOut` function from `SupabaseProvider`",
+    "Unit tests updated to assert the new item renders and description element is absent",
+    "Architecture diagram updated to mention Logout icon"
+  ],
+  "nonFunctional": {},
+  "edgeCases": [
+    "Sidebar collapsed state still shows tooltip with caption on hover",
+    "Sign out action should still redirect user via auth listener even if the click happens while network is slow"
+  ],
+  "dependencies": [
+    "signOut method from `SupabaseProvider`"
+  ],
+  "deliverables": [
+    "src/components/layout/Sidebar.tsx",
+    "src/components/layout/__tests__/Sidebar.test.tsx",
+    "docs/architecture.puml",
+    "Milestones.md",
+    "task_definition_UI-109.json",
+    "subagents_report/accountable.md",
+    "subagents_report/responsible.md",
+    "subagents_report/consulted.md",
+    "subagents_report/informed.md",
+    "subagents_report/unit.md",
+    "subagents_report/architectureDiagram.md"
+  ],
+  "estimate": "1 story point",
+  "version": "1.0.0",
+  "changelog": ["Initial task definition"],
+  "milestone": "MILESTONE-1",
+  "raci": {
+    "accountable": "agent-A-UI109",
+    "responsible": "agent-R-UI109",
+    "consulted": "agent-C-UI109",
+    "informed": "agent-I-UI109"
+  },
+  "testMatrix": {
+    "unit": true,
+    "integration": false,
+    "e2e": false
+  },
+  "docsMatrix": {
+    "dependencyGraph": false,
+    "architectureDiagram": true,
+    "dbSchemaBackup": false
+  },
+  "created": "2025-07-10T00:00:00Z",
+  "due": "2025-07-13T23:00:00Z"
+}


### PR DESCRIPTION
## Summary
- add Power icon logout entry to `bottomNavItems`
- style logout icon in red and call `signOut`
- avoid rendering logout description
- document logout button in architecture diagram
- track UI-109 in Milestones and task definition JSON
- update subagent RACI reports
- add tests for logout button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bec2434f4832b882f8568a344240b