### PR TITLE
Add shipping info fields and delivery API

### DIFF
--- a/src/app/api/__tests__/group-delivery-info.test.ts
+++ b/src/app/api/__tests__/group-delivery-info.test.ts
@@ -1,0 +1,20 @@
+/** @jest-environment node */
+import { GET } from '../group-delivery-info/[id]/route'
+
+jest.mock('@supabase/auth-helpers-nextjs', () => ({
+  createRouteHandlerClient: jest.fn(() => ({
+    auth: { getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'u1' } } }) },
+    from: jest.fn(() => {
+      const eq = jest.fn().mockResolvedValue({ data: [], error: null })
+      return { select: jest.fn().mockReturnValue({ eq }) }
+    })
+  }))
+}))
+
+describe('group delivery info API', () => {
+  it('returns data', async () => {
+    const req = new Request('http://localhost')
+    const res = await GET(req as any, { params: { id: 'g1' } } as any)
+    expect(res.status).toBe(200)
+  })
+})

--- a/src/app/api/group-delivery-info/[id]/route.ts
+++ b/src/app/api/group-delivery-info/[id]/route.ts
@@ -1,0 +1,17 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  const supabase = createRouteHandlerClient({ cookies })
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data, error } = await supabase
+    .from('group_members')
+    .select('user_id, first_name, last_name, shipping_address, phone_number')
+    .eq('group_id', params.id)
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json(data)
+}

--- a/src/app/profile/__tests__/page.test.tsx
+++ b/src/app/profile/__tests__/page.test.tsx
@@ -30,6 +30,12 @@ jest.mock('@/components/layout/Header', () => {
   };
 });
 
+// Mock ShippingDetailsForm to avoid loading client dependencies
+jest.mock('@/components/profile/ShippingDetailsForm', () => ({
+  __esModule: true,
+  ShippingDetailsForm: () => <div data-testid="shipping-form" />
+}));
+
 // Mock Image component
 jest.mock('next/image', () => ({
     __esModule: true,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
 import { User, Wallet, Settings, Bell } from 'lucide-react'
 import { WalletCard } from '@/components/profile/WalletCard'
+import { ShippingDetailsForm } from '@/components/profile/ShippingDetailsForm'
 import Image from 'next/image'
 import type { Session } from '@supabase/supabase-js' // Import Session type
 
@@ -119,6 +120,8 @@ export default async function ProfilePage() {
                       />
                     </div>
                   </div>
+                  {/* Shipping details update form */}
+                  <ShippingDetailsForm />
                 </CardContent>
               </Card>
 

--- a/src/components/profile/ShippingDetailsForm.tsx
+++ b/src/components/profile/ShippingDetailsForm.tsx
@@ -1,0 +1,58 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { useSupabase } from '@/contexts/SupabaseProvider'
+import { Button } from '@/components/ui/Button'
+
+export function ShippingDetailsForm() {
+  const { profile, updateProfile } = useSupabase()
+  const [form, setForm] = useState({
+    first_name: '',
+    last_name: '',
+    shipping_address: '',
+    phone_number: ''
+  })
+
+  useEffect(() => {
+    if (profile) {
+      setForm({
+        first_name: profile.first_name || '',
+        last_name: profile.last_name || '',
+        shipping_address: profile.shipping_address || '',
+        phone_number: profile.phone_number || ''
+      })
+    }
+  }, [profile])
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await updateProfile(form)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 mt-6">
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="first_name" className="text-sm font-medium">First Name</label>
+          <input id="first_name" name="first_name" value={form.first_name} onChange={handleChange} className="w-full rounded-lg border bg-background px-3 py-2" />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="last_name" className="text-sm font-medium">Last Name</label>
+          <input id="last_name" name="last_name" value={form.last_name} onChange={handleChange} className="w-full rounded-lg border bg-background px-3 py-2" />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label htmlFor="shipping_address" className="text-sm font-medium">Shipping Address</label>
+          <textarea id="shipping_address" name="shipping_address" value={form.shipping_address} onChange={handleChange} className="w-full rounded-lg border bg-background px-3 py-2" />
+        </div>
+        <div className="space-y-2 md:col-span-2">
+          <label htmlFor="phone_number" className="text-sm font-medium">Phone Number</label>
+          <input id="phone_number" name="phone_number" value={form.phone_number} onChange={handleChange} className="w-full rounded-lg border bg-background px-3 py-2" />
+        </div>
+      </div>
+      <Button type="submit">Save</Button>
+    </form>
+  )
+}

--- a/src/lib/supabase/__tests__/groups.test.ts
+++ b/src/lib/supabase/__tests__/groups.test.ts
@@ -1,0 +1,47 @@
+/** @jest-environment node */
+import { joinGroup } from '../groups'
+import supabaseClient from '../supabaseClient'
+
+jest.mock('../supabaseClient', () => ({
+  __esModule: true,
+  default: { from: jest.fn(), rpc: jest.fn() }
+}))
+
+describe('joinGroup', () => {
+  const mockFrom = supabaseClient.from as jest.Mock
+  const mockRpc = supabaseClient.rpc as jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function setupProfile(profile: any) {
+    const obj: any = {}
+    obj.select = jest.fn().mockReturnValue(obj)
+    obj.eq = jest.fn().mockReturnValue(obj)
+    obj.single = jest.fn().mockResolvedValue({ data: profile, error: null })
+    mockFrom.mockReturnValueOnce(obj)
+  }
+
+  function setupMemberCheck() {
+    const obj: any = {}
+    obj.select = jest.fn().mockReturnValue(obj)
+    obj.eq = jest.fn().mockReturnValue(obj)
+    obj.single = jest.fn().mockResolvedValue({ data: null, error: null })
+    mockFrom.mockReturnValueOnce(obj)
+  }
+
+  function setupInsert() {
+    const obj: any = {}
+    obj.insert = jest.fn().mockReturnValue(obj)
+    obj.select = jest.fn().mockReturnValue(obj)
+    obj.single = jest.fn().mockResolvedValue({ data: { id: 'm1' }, error: null })
+    mockFrom.mockReturnValueOnce(obj)
+  }
+
+  it('throws when shipping info missing', async () => {
+    setupProfile({ first_name: null, last_name: null, shipping_address: null, phone_number: null })
+    setupMemberCheck()
+    await expect(joinGroup('g1', 'u1')).rejects.toThrow('Missing shipping information')
+  })
+})

--- a/src/lib/supabase/__tests__/user.test.ts
+++ b/src/lib/supabase/__tests__/user.test.ts
@@ -1,0 +1,29 @@
+/** @jest-environment node */
+import { updateUserProfile } from '../user'
+import supabaseClient from '../supabaseClient'
+
+jest.mock('../supabaseClient', () => ({
+  __esModule: true,
+  default: { from: jest.fn() }
+}))
+
+describe('user profile helpers', () => {
+  const mockFrom = supabaseClient.from as jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('updates profile', async () => {
+    const obj: any = {}
+    obj.update = jest.fn().mockReturnValue(obj)
+    obj.eq = jest.fn().mockReturnValue(obj)
+    obj.select = jest.fn().mockReturnValue(obj)
+    obj.single = jest.fn().mockResolvedValue({ data: { id: 'u1' }, error: null })
+    mockFrom.mockReturnValue(obj)
+
+    const res = await updateUserProfile('u1', { first_name: 'A' })
+    expect(res.id).toBe('u1')
+    expect(obj.update).toHaveBeenCalledWith({ first_name: 'A' })
+  })
+})

--- a/src/lib/supabase/groups.ts
+++ b/src/lib/supabase/groups.ts
@@ -200,6 +200,17 @@ export async function createGroup(group: {
 }
 
 export async function joinGroup(groupId: string, userId: string) {
+  const { data: profile, error: profileError } = await supabaseClient
+    .from('user_profiles')
+    .select('first_name, last_name, shipping_address, phone_number')
+    .eq('id', userId)
+    .single()
+
+  if (profileError) throw profileError
+  if (!profile?.first_name || !profile.last_name || !profile.shipping_address || !profile.phone_number) {
+    throw new Error('Missing shipping information')
+  }
+
   const { data: existingMember, error: checkError } = await supabaseClient
     .from('group_members')
     .select('id')
@@ -215,6 +226,10 @@ export async function joinGroup(groupId: string, userId: string) {
     .insert({
       group_id: groupId,
       user_id: userId,
+      first_name: profile.first_name,
+      last_name: profile.last_name,
+      shipping_address: profile.shipping_address,
+      phone_number: profile.phone_number,
       vote_status: 'pending',
       is_admin: false,
     })

--- a/src/lib/supabase/user.ts
+++ b/src/lib/supabase/user.ts
@@ -14,12 +14,16 @@ export async function getUserProfile(userId: string) {
 
 export async function updateUserProfile(userId: string, updates: {
   full_name?: string | null
+  first_name?: string | null
+  last_name?: string | null
   avatar_url?: string | null
   role?: UserRole
   account_name?: string | null
   account_number?: string | null
   bank_name?: string | null
   currency?: string | null
+  shipping_address?: string | null
+  phone_number?: string | null
 }) {
   const { data, error } = await supabaseClient
     .from('user_profiles')
@@ -35,12 +39,16 @@ export async function updateUserProfile(userId: string, updates: {
 export async function createUserProfile(profile: {
   id: string
   full_name: string | null
+  first_name?: string | null
+  last_name?: string | null
   avatar_url: string | null
   role: UserRole
   account_name?: string | null
   account_number?: string | null
   bank_name?: string | null
   currency?: string | null
+  shipping_address?: string | null
+  phone_number?: string | null
 }) {
   const { data, error } = await supabaseClient
     .from('user_profiles')
@@ -52,6 +60,10 @@ export async function createUserProfile(profile: {
       account_number: profile.account_number ?? null,
       bank_name: profile.bank_name ?? null,
       currency: profile.currency ?? null,
+      first_name: profile.first_name ?? null,
+      last_name: profile.last_name ?? null,
+      shipping_address: profile.shipping_address ?? null,
+      phone_number: profile.phone_number ?? null,
     })
     .select()
     .single()

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -20,6 +20,8 @@ export interface Database {
         Row: {
           id: string
           full_name: string | null
+          first_name: string | null
+          last_name: string | null
           avatar_url: string | null
           role: UserRole
           wallet_balance: number
@@ -28,12 +30,16 @@ export interface Database {
           account_number: string | null
           bank_name: string | null
           currency: string | null
+          shipping_address: string | null
+          phone_number: string | null
           created_at: string
           updated_at: string
         }
         Insert: {
           id: string
           full_name?: string | null
+          first_name?: string | null
+          last_name?: string | null
           avatar_url?: string | null
           role?: UserRole
           wallet_balance?: number
@@ -42,12 +48,16 @@ export interface Database {
           account_number?: string | null
           bank_name?: string | null
           currency?: string | null
+          shipping_address?: string | null
+          phone_number?: string | null
           created_at?: string
           updated_at?: string
         }
         Update: {
           id?: string
           full_name?: string | null
+          first_name?: string | null
+          last_name?: string | null
           avatar_url?: string | null
           role?: UserRole
           wallet_balance?: number
@@ -56,6 +66,8 @@ export interface Database {
           account_number?: string | null
           bank_name?: string | null
           currency?: string | null
+          shipping_address?: string | null
+          phone_number?: string | null
           created_at?: string
           updated_at?: string
         }
@@ -143,6 +155,12 @@ export interface Database {
           user_id: string
           amount: number
           joined_at: string
+          vote_status: 'pending' | 'approved' | 'rejected' | null
+          is_admin: boolean
+          first_name: string | null
+          last_name: string | null
+          shipping_address: string | null
+          phone_number: string | null
         }
         Insert: {
           id?: string
@@ -150,6 +168,12 @@ export interface Database {
           user_id: string
           amount: number
           joined_at?: string
+          vote_status?: 'pending' | 'approved' | 'rejected' | null
+          is_admin?: boolean
+          first_name?: string | null
+          last_name?: string | null
+          shipping_address?: string | null
+          phone_number?: string | null
         }
         Update: {
           id?: string
@@ -157,6 +181,12 @@ export interface Database {
           user_id?: string
           amount?: number
           joined_at?: string
+          vote_status?: 'pending' | 'approved' | 'rejected' | null
+          is_admin?: boolean
+          first_name?: string | null
+          last_name?: string | null
+          shipping_address?: string | null
+          phone_number?: string | null
         }
       }
       transactions: {


### PR DESCRIPTION
## Summary
- extend user profile schema with shipping details
- regenerate database types
- add helper for editing shipping details
- show shipping form on profile page
- enforce shipping info when joining a group
- expose delivery info via new API route
- add tests for new utilities and routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687134d8dc48832ba188e3116cf73e31