### PR TITLE
UI-111 Personal info modal

### DIFF
--- a/Milestones.md
+++ b/Milestones.md
@@ -11,6 +11,7 @@
 - **UI-108** - Add divider above bottom sidebar icons (status: draft)
 - **UI-109** - Add Logout icon to sidebar bottom navigation (status: draft)
 - **UI-110** - Make logo clickable to buyer explore page when signed in (status: draft)
+- **UI-111** - Streamline Personal Info Modal with Edit Flow (status: draft)
 
 ## MILESTONE-2 – Core Feature Enhancements
 - **Start:** 2023-10-27

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -24,4 +24,7 @@ note bottom of Main
   Product listing form pulls vendors via API
   and stores selected_user_vendor_id
 end note
+note bottom of Main
+  PersonalInfoModal updates user_profiles via updateProfile
+end note
 @enduml

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -4,3 +4,4 @@
 - API `/api/user-vendors` uses Supabase client
 - `VendorListManager` UI fetches `/api/user-vendors`
 - `ProductListingForm` requires vendor selection
+- `PersonalInfoModal` uses `updateProfile` from SupabaseProvider

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -7,3 +7,7 @@
 ## Product Listing Vendor Selection
 - Listing a product requires picking a vendor from the list.
 - The product stores the vendor id for participants to reference.
+
+## Personal Info Modal
+- Shows name and email with optional phone and address.
+- Edit button opens modal saving changes to profile.

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -3,3 +3,4 @@
 1. User manages a private list of suppliers.
 2. Product listing form fetches this list and requires one to be selected.
 3. Selected vendor id is stored with the product so group participants can see supplier details.
+4. PersonalInfoModal allows editing name, phone and address with updates saved on close.

--- a/src/app/profile/__tests__/page.test.tsx
+++ b/src/app/profile/__tests__/page.test.tsx
@@ -36,6 +36,12 @@ jest.mock('@/components/profile/ShippingDetailsForm', () => ({
   ShippingDetailsForm: () => <div data-testid="shipping-form" />
 }));
 
+// Mock PersonalInfoSection to avoid client dependencies
+jest.mock('@/components/profile/PersonalInfoSection', () => ({
+  __esModule: true,
+  PersonalInfoSection: () => <div data-testid="personal-info" />
+}));
+
 // Mock Image component
 jest.mock('next/image', () => ({
     __esModule: true,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from 'next/navigation'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/Card'
 import { User, Wallet, Settings, Bell } from 'lucide-react'
 import { WalletCard } from '@/components/profile/WalletCard'
-import { ShippingDetailsForm } from '@/components/profile/ShippingDetailsForm'
+import { PersonalInfoSection } from '@/components/profile/PersonalInfoSection'
 import Image from 'next/image'
 import type { Session } from '@supabase/supabase-js' // Import Session type
 
@@ -98,30 +98,7 @@ export default async function ProfilePage() {
                     </div>
                   </div>
 
-                  <div className="mt-8 grid gap-6 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <label htmlFor="fullName" className="text-sm font-medium">Full Name</label>
-                      <input
-                        id="fullName"
-                        type="text"
-                        value={profile?.full_name || ''}
-                        className="w-full rounded-lg border bg-background px-3 py-2"
-                        readOnly
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <label htmlFor="email" className="text-sm font-medium">Email</label>
-                      <input
-                        id="email"
-                        type="email"
-                        value={session.user.email || ''} // Use session.user.email as a fallback
-                        className="w-full rounded-lg border bg-background px-3 py-2"
-                        readOnly
-                      />
-                    </div>
-                  </div>
-                  {/* Shipping details update form */}
-                  <ShippingDetailsForm />
+                  <PersonalInfoSection />
                 </CardContent>
               </Card>
 

--- a/src/components/profile/PersonalInfoModal.tsx
+++ b/src/components/profile/PersonalInfoModal.tsx
@@ -1,0 +1,122 @@
+'use client'
+import { useState, useEffect } from 'react'
+import { useSupabase } from '@/contexts/SupabaseProvider'
+import { Button } from '@/components/ui/Button'
+import { X } from 'lucide-react'
+
+interface PersonalInfoModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function PersonalInfoModal({ isOpen, onClose }: PersonalInfoModalProps) {
+  const { profile, updateProfile } = useSupabase()
+  const [form, setForm] = useState({
+    first_name: '',
+    last_name: '',
+    phone_number: '',
+    shipping_address: ''
+  })
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isOpen && profile) {
+      setForm({
+        first_name: profile.first_name || '',
+        last_name: profile.last_name || '',
+        phone_number: profile.phone_number || '',
+        shipping_address: profile.shipping_address || ''
+      })
+      setError(null)
+    }
+  }, [isOpen, profile])
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSave = async () => {
+    setLoading(true)
+    try {
+      await updateProfile({
+        first_name: form.first_name,
+        last_name: form.last_name,
+        phone_number: form.phone_number,
+        shipping_address: form.shipping_address,
+        full_name: `${form.first_name} ${form.last_name}`.trim()
+      })
+      onClose()
+    } catch (err) {
+      console.error('Failed to update profile', err)
+      setError('Failed to save changes')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
+      <div
+        className="bg-white dark:bg-neutral-850 p-6 rounded-lg shadow-xl w-full max-w-sm"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">Edit Personal Info</h2>
+          <button onClick={onClose} className="text-neutral-500 hover:text-neutral-700">
+            <X size={20} />
+          </button>
+        </div>
+        <div className="space-y-2">
+          <input
+            name="first_name"
+            value={form.first_name}
+            onChange={handleChange}
+            placeholder="First Name"
+            className="w-full border rounded px-2 py-1"
+          />
+          <input
+            name="last_name"
+            value={form.last_name}
+            onChange={handleChange}
+            placeholder="Last Name"
+            className="w-full border rounded px-2 py-1"
+          />
+          <input
+            name="phone_number"
+            value={form.phone_number}
+            onChange={handleChange}
+            placeholder="Phone Number"
+            className="w-full border rounded px-2 py-1"
+          />
+          <textarea
+            name="shipping_address"
+            value={form.shipping_address}
+            onChange={handleChange}
+            placeholder="Shipping Address"
+            className="w-full border rounded px-2 py-1"
+          />
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <div className="flex gap-2 pt-1">
+            <Button onClick={handleSave} disabled={loading}>
+              Save
+            </Button>
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/profile/PersonalInfoSection.tsx
+++ b/src/components/profile/PersonalInfoSection.tsx
@@ -1,0 +1,69 @@
+'use client'
+import { useState } from 'react'
+import { useSupabase } from '@/contexts/SupabaseProvider'
+import { Button } from '@/components/ui/Button'
+import { PersonalInfoModal } from './PersonalInfoModal'
+
+export function PersonalInfoSection() {
+  const { profile, session } = useSupabase()
+  const [showMore, setShowMore] = useState(false)
+  const [open, setOpen] = useState(false)
+
+  const toggleMore = () => setShowMore(prev => !prev)
+  const openModal = () => setOpen(true)
+  const closeModal = () => setOpen(false)
+
+  return (
+    <div>
+      <div className="mt-8 grid gap-6 md:grid-cols-2">
+        <div className="space-y-2">
+          <label htmlFor="pi_fullname" className="text-sm font-medium">Full Name</label>
+          <input
+            id="pi_fullname"
+            value={profile?.full_name || ''}
+            readOnly
+            className="w-full rounded-lg border bg-background px-3 py-2"
+          />
+        </div>
+        <div className="space-y-2">
+          <label htmlFor="pi_email" className="text-sm font-medium">Email</label>
+          <input
+            id="pi_email"
+            value={session?.user.email || ''}
+            readOnly
+            className="w-full rounded-lg border bg-background px-3 py-2"
+          />
+        </div>
+        {showMore && (
+          <>
+            <div className="space-y-2">
+              <label htmlFor="pi_phone" className="text-sm font-medium">Phone Number</label>
+              <input
+                id="pi_phone"
+                value={profile?.phone_number || ''}
+                readOnly
+                className="w-full rounded-lg border bg-background px-3 py-2"
+              />
+            </div>
+            <div className="space-y-2 md:col-span-2">
+              <label htmlFor="pi_address" className="text-sm font-medium">Shipping Address</label>
+              <textarea
+                id="pi_address"
+                value={profile?.shipping_address || ''}
+                readOnly
+                className="w-full rounded-lg border bg-background px-3 py-2"
+              />
+            </div>
+          </>
+        )}
+      </div>
+      <div className="mt-4 flex gap-2">
+        <Button variant="secondary" onClick={toggleMore}>
+          {showMore ? 'Hide' : 'See More'}
+        </Button>
+        <Button onClick={openModal}>Edit Personal Information</Button>
+      </div>
+      <PersonalInfoModal isOpen={open} onClose={closeModal} />
+    </div>
+  )
+}

--- a/src/components/profile/__tests__/PersonalInfoModal.test.tsx
+++ b/src/components/profile/__tests__/PersonalInfoModal.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { PersonalInfoSection } from '../PersonalInfoSection'
+
+const mockUpdateProfile = jest.fn()
+const mockUseSupabase = jest.fn()
+
+jest.mock('@/contexts/SupabaseProvider', () => ({
+  useSupabase: () => mockUseSupabase()
+}))
+
+describe('PersonalInfoSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseSupabase.mockReturnValue({
+      profile: {
+        full_name: 'Test User',
+        first_name: 'Test',
+        last_name: 'User',
+        phone_number: '123',
+        shipping_address: '123 Street'
+      },
+      session: { user: { email: 'test@example.com' } },
+      updateProfile: mockUpdateProfile
+    })
+  })
+
+  it('hides phone and address by default', () => {
+    render(<PersonalInfoSection />)
+    expect(screen.queryByDisplayValue('123')).toBeNull()
+    expect(screen.queryByDisplayValue('123 Street')).toBeNull()
+  })
+
+  it('shows phone and address when See More clicked', () => {
+    render(<PersonalInfoSection />)
+    fireEvent.click(screen.getByText('See More'))
+    expect(screen.getByDisplayValue('123')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('123 Street')).toBeInTheDocument()
+  })
+
+  it('saves updates and closes modal', async () => {
+    render(<PersonalInfoSection />)
+    fireEvent.click(screen.getByText('Edit Personal Information'))
+    const phoneInput = screen.getByPlaceholderText('Phone Number')
+    fireEvent.change(phoneInput, { target: { value: '999' } })
+    fireEvent.click(screen.getByText('Save'))
+    await waitFor(() =>
+      expect(mockUpdateProfile).toHaveBeenCalledWith(
+        expect.objectContaining({ phone_number: '999' })
+      )
+    )
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+  })
+})

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -9,3 +9,4 @@
 2025-07-10 - Confirmed logout icon added to bottom navigation for UI-109.
 2025-07-11 - Confirmed clickable logo link when signed in for UI-110.
 2025-07-11 - Implemented vendor management features.
+2025-07-11 - Streamlined personal info modal with edit flow for UI-111.

--- a/subagents_report/architectureDiagram.md
+++ b/subagents_report/architectureDiagram.md
@@ -1,1 +1,2 @@
 Architecture diagram updated with vendor flow.
+Diagram updated for personal info modal in UI-111.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -9,3 +9,4 @@
 2025-07-10 - No consultations were necessary for UI-109.
 2025-07-11 - No consultations were necessary for UI-110.
 2025-07-11 - Implemented vendor management features.
+2025-07-11 - No consultations were necessary for UI-111.

--- a/subagents_report/dependencyGraph.md
+++ b/subagents_report/dependencyGraph.md
@@ -1,1 +1,2 @@
 Updated dependency graph for FEAT-VEND-MGMT-001 recorded.
+Personal info modal dependencies documented for UI-111.

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -1,1 +1,2 @@
 Feedback: Vendor management feature integrated.
+Feedback: Personal info modal flow confirmed.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -9,3 +9,4 @@
 2025-07-10 - Stakeholders informed about logout button in sidebar for UI-109.
 2025-07-11 - Stakeholders informed about clickable logo when logged in for UI-110.
 2025-07-11 - Implemented vendor management features.
+2025-07-11 - Stakeholders informed about streamlined personal info editing for UI-111.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -9,3 +9,4 @@
 2025-07-10 - Added logout icon with tests and docs for UI-109.
 2025-07-11 - Made logo clickable when logged in and added tests for UI-110.
 2025-07-11 - Implemented vendor management features.
+2025-07-11 - Added PersonalInfoModal and tests for UI-111.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -9,3 +9,4 @@
 2025-07-10 - Added test to verify logout icon renders without description for UI-109.
 2025-07-11 - Lint and unit tests passed for UI-110.
 2025-07-11 - Unit tests added for vendor management.
+2025-07-11 - Unit tests cover PersonalInfoModal hide/show and save flow for UI-111.


### PR DESCRIPTION
## Summary
- streamline profile personal info flow with PersonalInfoModal
- include PersonalInfoSection on profile page
- document new modal flow and update architecture
- record UI-111 in milestone and subagent reports
- add unit tests for modal interactions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68714e29d430832bb066224342e9a066