### PR TITLE
Fix Personal Info reveal

### DIFF
--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -30,5 +30,6 @@ end note
 note bottom of Main
   Personal info card reveals phone and address
   below a centered avatar when See More is clicked
+  and slides out from beneath the card
 end note
 @enduml

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -6,3 +6,4 @@
 - `ProductListingForm` requires vendor selection
 - `PersonalInfoModal` uses `updateProfile` from SupabaseProvider
 - `PersonalInfoSection` toggles phone and address visibility on See More
+- `PersonalInfoSection` reveal uses translate-y and max-height classes for smooth slide

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -11,4 +11,4 @@
 ## Personal Info Modal
 - Shows a single centered avatar with name and email.
 - Edit button (pencil icon) opens the modal to save changes.
-- Phone and address remain hidden below until "See More" is clicked, then slide into view.
+ - Phone and address slide out from beneath the card when "See More" is clicked, revealing details smoothly within 300ms. The edit icon is vertically centered on the right.

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -4,4 +4,4 @@
 2. Product listing form fetches this list and requires one to be selected.
 3. Selected vendor id is stored with the product so group participants can see supplier details.
 4. PersonalInfoModal allows editing name, phone and address with updates saved on close.
-5. Personal info card shows one centered avatar and email. Phone and address stay hidden until the See More tab is clicked.
+5. Personal info card shows one centered avatar and email. Hidden phone and address slide out from beneath the card when the See More tab is clicked, with the edit icon vertically centered on the right.

--- a/src/components/profile/PersonalInfoSection.tsx
+++ b/src/components/profile/PersonalInfoSection.tsx
@@ -33,36 +33,38 @@ export function PersonalInfoSection() {
         <p className="mt-1 text-sm text-muted-foreground text-center">
           {session?.user.email || ''}
         </p>
-        <div
-          className={clsx(
-            'grid w-full gap-2 transition-all duration-200 text-center',
-            expanded ? 'max-h-40 opacity-100 mt-4' : 'max-h-0 overflow-hidden opacity-0'
-          )}
-          aria-hidden={!expanded}
-        >
-          {expanded && profile?.phone_number && (
-            <p data-testid="phone" className="text-sm text-center">
-              {profile.phone_number}
-            </p>
-          )}
-          {expanded && profile?.shipping_address && (
-            <p data-testid="address" className="text-sm text-center">
-              {profile.shipping_address}
-            </p>
-          )}
+        <div className="relative mt-4 w-full">
+          <div
+            className={clsx(
+              'absolute inset-x-0 bottom-0 grid gap-2 bg-background text-center transition-all duration-300',
+              expanded ? 'max-h-40 translate-y-0' : 'max-h-6 translate-y-[95%]'
+            )}
+            aria-hidden={!expanded}
+          >
+            {expanded && profile?.phone_number && (
+              <p data-testid="phone" className="text-sm">
+                {profile.phone_number}
+              </p>
+            )}
+            {expanded && profile?.shipping_address && (
+              <p data-testid="address" className="text-sm">
+                {profile.shipping_address}
+              </p>
+            )}
+            <button
+              onClick={toggle}
+              className="rounded-t-md bg-muted px-3 py-1 text-sm font-medium"
+            >
+              {expanded ? 'Hide' : 'See More'}
+            </button>
+          </div>
         </div>
       </div>
-      <button
-        onClick={toggle}
-        className="absolute left-1/2 top-full mt-2 -translate-x-1/2 rounded-t-md bg-muted px-3 py-1 text-sm font-medium"
-      >
-        {expanded ? 'Hide' : 'See More'}
-      </button>
       <Button
         size="sm"
         onClick={openModal}
         aria-label="Edit Personal Information"
-        className="absolute right-2 top-2 p-2"
+        className="absolute right-2 top-1/2 -translate-y-1/2 p-2"
       >
         <Pencil className="h-4 w-4" />
       </Button>

--- a/src/components/profile/__tests__/PersonalInfoModal.test.tsx
+++ b/src/components/profile/__tests__/PersonalInfoModal.test.tsx
@@ -36,6 +36,7 @@ describe('PersonalInfoSection', () => {
     fireEvent.click(screen.getByText('See More'))
     expect(screen.getByTestId('phone')).toBeInTheDocument()
     expect(screen.getByTestId('address')).toBeInTheDocument()
+    expect(screen.getByText('Hide')).toBeInTheDocument()
   })
 
   it('handles missing details gracefully', () => {
@@ -50,10 +51,12 @@ describe('PersonalInfoSection', () => {
     expect(screen.queryByTestId('address')).toBeNull()
   })
 
-  it('edit button contains only an icon', () => {
+  it('edit button contains only an icon and is vertically centered', () => {
     render(<PersonalInfoSection />)
     const btn = screen.getByLabelText('Edit Personal Information')
     expect(btn).not.toHaveTextContent(/edit/i)
+    expect(btn.className).toMatch(/top-1\/2/)
+    expect(btn.className).toMatch(/-translate-y-1\/2/)
   })
 
   it('saves updates and closes modal', async () => {

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -12,3 +12,4 @@
 2025-07-11 - Streamlined personal info modal with edit flow for UI-111.
 2025-07-11 - Confirmed sliding reveal personal info card for UI-112.
 2025-07-12 - Confirmed card reveal bug fixed and avatar duplicates removed for UI-113.
+2025-07-12 - Confirmed sliding reveal and centered edit icon for UI-114.

--- a/subagents_report/architectureDiagram.md
+++ b/subagents_report/architectureDiagram.md
@@ -1,3 +1,4 @@
 Architecture diagram updated with vendor flow.
 Diagram updated for personal info modal in UI-111.
 Diagram updated for reveal fix in UI-113.
+Diagram updated for sliding reveal and centered edit icon in UI-114.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -12,3 +12,4 @@
 2025-07-11 - No consultations were necessary for UI-111.
 2025-07-11 - No consultations were necessary for UI-112.
 2025-07-12 - No consultations were necessary for UI-113.
+2025-07-12 - No consultations were necessary for UI-114.

--- a/subagents_report/dependencyGraph.md
+++ b/subagents_report/dependencyGraph.md
@@ -1,3 +1,4 @@
 Updated dependency graph for FEAT-VEND-MGMT-001 recorded.
 Personal info modal dependencies documented for UI-111.
 Personal info card reveal dependencies updated for UI-113.
+Sliding reveal and icon alignment dependencies documented for UI-114.

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -2,3 +2,4 @@ Feedback: Vendor management feature integrated.
 Feedback: Personal info modal flow confirmed.
 Feedback: Please confirm the new personal info sliding card layout for UI-112.
 Feedback: Confirmed layout change with single avatar and reveal fix for UI-113.
+Feedback: Please confirm sliding reveal toggle and edit icon alignment for UI-114.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -12,3 +12,4 @@
 2025-07-11 - Stakeholders informed about streamlined personal info editing for UI-111.
 2025-07-11 - Stakeholders informed about new sliding personal info layout for UI-112.
 2025-07-12 - Stakeholders informed about personal info reveal fix for UI-113.
+2025-07-12 - Stakeholders notified about sliding reveal toggle and icon alignment for UI-114.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -12,3 +12,4 @@
 2025-07-11 - Added PersonalInfoModal and tests for UI-111.
 2025-07-11 - Redesigned personal info card with slide out details and icon edit button for UI-112.
 2025-07-12 - Fixed personal info reveal and centered details with new tests for UI-113.
+2025-07-12 - Implemented sliding reveal bug fix and updated tests for UI-114.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -12,3 +12,4 @@
 2025-07-11 - Unit tests cover PersonalInfoModal hide/show and save flow for UI-111.
 2025-07-11 - Unit tests updated for sliding reveal and icon button for UI-112.
 2025-07-12 - Tests cover personal info reveal bug fix for UI-113.
+2025-07-12 - Added unit test for sliding reveal toggle and edit icon alignment for UI-114.


### PR DESCRIPTION
## Summary
- slide out personal info details from beneath card
- center edit icon
- update unit tests for reveal toggle and icon alignment
- refresh dependency graph, architecture diagram, functional and feature docs
- log new entry in subagents reports

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68718a98449c832b851d6f47cdaff65d