### PR TITLE
UI-114 fix See More reveal animation

### DIFF
--- a/Milestones.md
+++ b/Milestones.md
@@ -14,6 +14,7 @@
 - **UI-111** - Streamline Personal Info Modal with Edit Flow (status: draft)
 - **UI-112** - Redesign Personal Info Card with Sliding Reveal (status: draft)
 - **UI-113** - Fix Personal Info Card Reveal and Remove Duplicate Avatar (status: draft)
+- **UI-114** - Fix and Style See More Reveal Animation (status: draft)
 
 ## MILESTONE-2 – Core Feature Enhancements
 - **Start:** 2023-10-27

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -28,7 +28,8 @@ note bottom of Main
   PersonalInfoModal updates user_profiles via updateProfile
 end note
 note bottom of Main
-  Personal info card reveals phone and address
-  below a centered avatar when See More is clicked
+  Personal info card uses a sliding See More tab
+  to reveal phone and address with an animated
+  slide-down effect
 end note
 @enduml

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -6,3 +6,4 @@
 - `ProductListingForm` requires vendor selection
 - `PersonalInfoModal` uses `updateProfile` from SupabaseProvider
 - `PersonalInfoSection` toggles phone and address visibility on See More
+- `PersonalInfoSection` reveals details with CSS slide animation and tab overlay

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -12,3 +12,4 @@
 - Shows a single centered avatar with name and email.
 - Edit button (pencil icon) opens the modal to save changes.
 - Phone and address remain hidden below until "See More" is clicked, then slide into view.
+- A black-bordered "See More" tab peeks below the card and slides phone and address into view when clicked.

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -4,4 +4,4 @@
 2. Product listing form fetches this list and requires one to be selected.
 3. Selected vendor id is stored with the product so group participants can see supplier details.
 4. PersonalInfoModal allows editing name, phone and address with updates saved on close.
-5. Personal info card shows one centered avatar and email. Phone and address stay hidden until the See More tab is clicked.
+5. Personal info card shows one centered avatar and email. A black-bordered "See More" tab peeks out from the bottom and slides phone and address into view when clicked.

--- a/src/components/profile/PersonalInfoSection.tsx
+++ b/src/components/profile/PersonalInfoSection.tsx
@@ -17,7 +17,7 @@ export function PersonalInfoSection() {
   const closeModal = () => setOpen(false)
 
   return (
-    <div className="relative">
+    <div className="relative pb-8">
       <div className="flex flex-col items-center">
         <div className="relative h-24 w-24 overflow-hidden rounded-full">
           <Image
@@ -35,8 +35,8 @@ export function PersonalInfoSection() {
         </p>
         <div
           className={clsx(
-            'grid w-full gap-2 transition-all duration-200 text-center',
-            expanded ? 'max-h-40 opacity-100 mt-4' : 'max-h-0 overflow-hidden opacity-0'
+            'grid w-full gap-2 text-center transition-[max-height] duration-300',
+            expanded ? 'max-h-40 mt-4' : 'max-h-0 overflow-hidden'
           )}
           aria-hidden={!expanded}
         >
@@ -54,7 +54,7 @@ export function PersonalInfoSection() {
       </div>
       <button
         onClick={toggle}
-        className="absolute left-1/2 top-full mt-2 -translate-x-1/2 rounded-t-md bg-muted px-3 py-1 text-sm font-medium"
+        className="absolute left-1/2 bottom-0 translate-y-1/2 -translate-x-1/2 rounded-t-md border border-black bg-muted px-3 py-1 text-sm font-medium"
       >
         {expanded ? 'Hide' : 'See More'}
       </button>

--- a/src/components/profile/__tests__/PersonalInfoModal.test.tsx
+++ b/src/components/profile/__tests__/PersonalInfoModal.test.tsx
@@ -38,6 +38,28 @@ describe('PersonalInfoSection', () => {
     expect(screen.getByTestId('address')).toBeInTheDocument()
   })
 
+  it('toggles details visibility and button text', () => {
+    render(<PersonalInfoSection />)
+    const toggleBtn = screen.getByText('See More')
+    fireEvent.click(toggleBtn)
+    expect(toggleBtn).toHaveTextContent('Hide')
+    expect(screen.getByTestId('phone')).toBeInTheDocument()
+    fireEvent.click(toggleBtn)
+    expect(toggleBtn).toHaveTextContent('See More')
+    expect(screen.queryByTestId('phone')).toBeNull()
+  })
+
+  it('handles rapid repeated clicks', () => {
+    render(<PersonalInfoSection />)
+    const btn = screen.getByText('See More')
+    fireEvent.click(btn)
+    fireEvent.click(btn)
+    fireEvent.click(btn)
+    expect(screen.getByTestId('phone')).toBeInTheDocument()
+    fireEvent.click(btn)
+    expect(screen.queryByTestId('phone')).toBeNull()
+  })
+
   it('handles missing details gracefully', () => {
     mockUseSupabase.mockReturnValue({
       profile: { full_name: 'Test User', avatar_url: '/test.jpg' },

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -12,3 +12,4 @@
 2025-07-11 - Streamlined personal info modal with edit flow for UI-111.
 2025-07-11 - Confirmed sliding reveal personal info card for UI-112.
 2025-07-12 - Confirmed card reveal bug fixed and avatar duplicates removed for UI-113.
+2025-07-12 - Confirmed See More tab overlay animation update for UI-114.

--- a/subagents_report/architectureDiagram.md
+++ b/subagents_report/architectureDiagram.md
@@ -1,3 +1,4 @@
 Architecture diagram updated with vendor flow.
 Diagram updated for personal info modal in UI-111.
 Diagram updated for reveal fix in UI-113.
+Diagram updated for sliding tab animation in UI-114.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -12,3 +12,4 @@
 2025-07-11 - No consultations were necessary for UI-111.
 2025-07-11 - No consultations were necessary for UI-112.
 2025-07-12 - No consultations were necessary for UI-113.
+2025-07-12 - No consultations were necessary for UI-114.

--- a/subagents_report/dependencyGraph.md
+++ b/subagents_report/dependencyGraph.md
@@ -1,3 +1,4 @@
 Updated dependency graph for FEAT-VEND-MGMT-001 recorded.
 Personal info modal dependencies documented for UI-111.
 Personal info card reveal dependencies updated for UI-113.
+Sliding See More tab animation dependencies updated for UI-114.

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -2,3 +2,4 @@ Feedback: Vendor management feature integrated.
 Feedback: Personal info modal flow confirmed.
 Feedback: Please confirm the new personal info sliding card layout for UI-112.
 Feedback: Confirmed layout change with single avatar and reveal fix for UI-113.
+Feedback: Please confirm the new sliding See More tab design for UI-114.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -12,3 +12,4 @@
 2025-07-11 - Stakeholders informed about streamlined personal info editing for UI-111.
 2025-07-11 - Stakeholders informed about new sliding personal info layout for UI-112.
 2025-07-12 - Stakeholders informed about personal info reveal fix for UI-113.
+2025-07-12 - Stakeholders informed about sliding See More tab design for UI-114.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -12,3 +12,4 @@
 2025-07-11 - Added PersonalInfoModal and tests for UI-111.
 2025-07-11 - Redesigned personal info card with slide out details and icon edit button for UI-112.
 2025-07-12 - Fixed personal info reveal and centered details with new tests for UI-113.
+2025-07-12 - Implemented sliding tab overlay animation and updated tests for UI-114.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -12,3 +12,4 @@
 2025-07-11 - Unit tests cover PersonalInfoModal hide/show and save flow for UI-111.
 2025-07-11 - Unit tests updated for sliding reveal and icon button for UI-112.
 2025-07-12 - Tests cover personal info reveal bug fix for UI-113.
+2025-07-12 - Tests verify See More tab toggle and rapid clicks for UI-114.


### PR DESCRIPTION
## Summary
- style See More tab so it's partially under the card
- animate PersonalInfoSection details slideout
- add toggle tests for rapid clicking
- document new See More sliding tab
- log milestone and report entries for UI-114

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687198369170832ba961832f0dac676b