### PR TITLE
UI-115 modal for personal info

### DIFF
--- a/Milestones.md
+++ b/Milestones.md
@@ -15,6 +15,7 @@
 - **UI-112** - Redesign Personal Info Card with Sliding Reveal (status: draft)
 - **UI-113** - Fix Personal Info Card Reveal and Remove Duplicate Avatar (status: draft)
 - **UI-114** - Fix and Style See More Reveal Animation (status: draft)
+- **UI-115** - Simplify Personal Info See More into Modal (status: draft)
 
 ## MILESTONE-2 – Core Feature Enhancements
 - **Start:** 2023-10-27

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -28,8 +28,8 @@ note bottom of Main
   PersonalInfoModal updates user_profiles via updateProfile
 end note
 note bottom of Main
-  Personal info card uses a sliding See More tab
-  to reveal phone and address with an animated
-  slide-down effect
+  Personal info card opens a modal to
+  display phone and address when
+  the See More button is clicked
 end note
 @enduml

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -5,5 +5,5 @@
 - `VendorListManager` UI fetches `/api/user-vendors`
 - `ProductListingForm` requires vendor selection
 - `PersonalInfoModal` uses `updateProfile` from SupabaseProvider
-- `PersonalInfoSection` toggles phone and address visibility on See More
-- `PersonalInfoSection` reveals details with CSS slide animation and tab overlay
+- `PersonalInfoViewModal` reads phone and address from SupabaseProvider
+- `PersonalInfoSection` opens `PersonalInfoViewModal` when See More is clicked

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -11,5 +11,5 @@
 ## Personal Info Modal
 - Shows a single centered avatar with name and email.
 - Edit button (pencil icon) opens the modal to save changes.
-- Phone and address remain hidden below until "See More" is clicked, then slide into view.
-- A black-bordered "See More" tab peeks below the card and slides phone and address into view when clicked.
+- "See More" opens a simple modal displaying phone and shipping address.
+- If no phone or address is set, the modal says "No additional details".

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -4,4 +4,4 @@
 2. Product listing form fetches this list and requires one to be selected.
 3. Selected vendor id is stored with the product so group participants can see supplier details.
 4. PersonalInfoModal allows editing name, phone and address with updates saved on close.
-5. Personal info card shows one centered avatar and email. A black-bordered "See More" tab peeks out from the bottom and slides phone and address into view when clicked.
+5. Personal info card shows one centered avatar and email. Tapping "See More" opens a modal that shows phone and address if available.

--- a/src/components/profile/PersonalInfoSection.tsx
+++ b/src/components/profile/PersonalInfoSection.tsx
@@ -1,20 +1,21 @@
 'use client'
 import { useState } from 'react'
 import Image from 'next/image'
-import clsx from 'clsx'
 import { Pencil } from 'lucide-react'
 import { useSupabase } from '@/contexts/SupabaseProvider'
 import { Button } from '@/components/ui/Button'
 import { PersonalInfoModal } from './PersonalInfoModal'
+import { PersonalInfoViewModal } from './PersonalInfoViewModal'
 
 export function PersonalInfoSection() {
   const { profile, session } = useSupabase()
-  const [expanded, setExpanded] = useState(false)
-  const [open, setOpen] = useState(false)
+  const [editOpen, setEditOpen] = useState(false)
+  const [viewOpen, setViewOpen] = useState(false)
 
-  const toggle = () => setExpanded(prev => !prev)
-  const openModal = () => setOpen(true)
-  const closeModal = () => setOpen(false)
+  const openEditModal = () => setEditOpen(true)
+  const closeEditModal = () => setEditOpen(false)
+  const openViewModal = () => setViewOpen(true)
+  const closeViewModal = () => setViewOpen(false)
 
   return (
     <div className="relative pb-8">
@@ -33,40 +34,23 @@ export function PersonalInfoSection() {
         <p className="mt-1 text-sm text-muted-foreground text-center">
           {session?.user.email || ''}
         </p>
-        <div
-          className={clsx(
-            'grid w-full gap-2 text-center transition-[max-height] duration-300',
-            expanded ? 'max-h-40 mt-4' : 'max-h-0 overflow-hidden'
-          )}
-          aria-hidden={!expanded}
-        >
-          {expanded && profile?.phone_number && (
-            <p data-testid="phone" className="text-sm text-center">
-              {profile.phone_number}
-            </p>
-          )}
-          {expanded && profile?.shipping_address && (
-            <p data-testid="address" className="text-sm text-center">
-              {profile.shipping_address}
-            </p>
-          )}
-        </div>
       </div>
       <button
-        onClick={toggle}
-        className="absolute left-1/2 bottom-0 translate-y-1/2 -translate-x-1/2 rounded-t-md border border-black bg-muted px-3 py-1 text-sm font-medium"
+        onClick={openViewModal}
+        className="absolute left-1/2 bottom-0 translate-y-1/2 -translate-x-1/2 rounded-t-md bg-muted px-3 py-1 text-sm font-medium"
       >
-        {expanded ? 'Hide' : 'See More'}
+        See More
       </button>
       <Button
         size="sm"
-        onClick={openModal}
+        onClick={openEditModal}
         aria-label="Edit Personal Information"
         className="absolute right-2 top-2 p-2"
       >
         <Pencil className="h-4 w-4" />
       </Button>
-      <PersonalInfoModal isOpen={open} onClose={closeModal} />
+      <PersonalInfoModal isOpen={editOpen} onClose={closeEditModal} />
+      <PersonalInfoViewModal isOpen={viewOpen} onClose={closeViewModal} />
     </div>
   )
 }

--- a/src/components/profile/PersonalInfoViewModal.tsx
+++ b/src/components/profile/PersonalInfoViewModal.tsx
@@ -1,0 +1,50 @@
+'use client'
+import { X } from 'lucide-react'
+import { useSupabase } from '@/contexts/SupabaseProvider'
+
+interface PersonalInfoViewModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function PersonalInfoViewModal({ isOpen, onClose }: PersonalInfoViewModalProps) {
+  const { profile } = useSupabase()
+
+  if (!isOpen) return null
+
+  const hasDetails = profile?.phone_number || profile?.shipping_address
+
+  return (
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+    >
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions */}
+      <div
+        className="bg-white dark:bg-neutral-850 p-6 rounded-lg shadow-xl w-full max-w-sm"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">Contact Details</h2>
+          <button onClick={onClose} aria-label="Close" className="text-neutral-500 hover:text-neutral-700">
+            <X size={20} />
+          </button>
+        </div>
+        {hasDetails ? (
+          <div className="space-y-2">
+            {profile?.phone_number && (
+              <p data-testid="modal-phone" className="text-sm text-center">{profile.phone_number}</p>
+            )}
+            {profile?.shipping_address && (
+              <p data-testid="modal-address" className="text-sm text-center">{profile.shipping_address}</p>
+            )}
+          </div>
+        ) : (
+          <p data-testid="no-details" className="text-sm text-muted-foreground text-center">No additional details</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/profile/__tests__/PersonalInfoModal.test.tsx
+++ b/src/components/profile/__tests__/PersonalInfoModal.test.tsx
@@ -25,28 +25,23 @@ describe('PersonalInfoSection', () => {
     })
   })
 
-  it('hides phone and address by default', () => {
+  it('modal closed by default', () => {
     render(<PersonalInfoSection />)
-    expect(screen.queryByTestId('phone')).toBeNull()
-    expect(screen.queryByTestId('address')).toBeNull()
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
-  it('shows phone and address when See More clicked', () => {
+  it('opens modal with details when See More clicked', () => {
     render(<PersonalInfoSection />)
     fireEvent.click(screen.getByText('See More'))
-    expect(screen.getByTestId('phone')).toBeInTheDocument()
-    expect(screen.getByTestId('address')).toBeInTheDocument()
+    expect(screen.getByTestId('modal-phone')).toBeInTheDocument()
+    expect(screen.getByTestId('modal-address')).toBeInTheDocument()
   })
 
-  it('toggles details visibility and button text', () => {
+  it('modal closes via X button', () => {
     render(<PersonalInfoSection />)
-    const toggleBtn = screen.getByText('See More')
-    fireEvent.click(toggleBtn)
-    expect(toggleBtn).toHaveTextContent('Hide')
-    expect(screen.getByTestId('phone')).toBeInTheDocument()
-    fireEvent.click(toggleBtn)
-    expect(toggleBtn).toHaveTextContent('See More')
-    expect(screen.queryByTestId('phone')).toBeNull()
+    fireEvent.click(screen.getByText('See More'))
+    fireEvent.click(screen.getByLabelText('Close'))
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('handles rapid repeated clicks', () => {
@@ -55,9 +50,9 @@ describe('PersonalInfoSection', () => {
     fireEvent.click(btn)
     fireEvent.click(btn)
     fireEvent.click(btn)
-    expect(screen.getByTestId('phone')).toBeInTheDocument()
-    fireEvent.click(btn)
-    expect(screen.queryByTestId('phone')).toBeNull()
+    expect(screen.getAllByRole('dialog').length).toBe(1)
+    fireEvent.click(screen.getByLabelText('Close'))
+    expect(screen.queryByRole('dialog')).toBeNull()
   })
 
   it('handles missing details gracefully', () => {
@@ -68,8 +63,13 @@ describe('PersonalInfoSection', () => {
     })
     render(<PersonalInfoSection />)
     fireEvent.click(screen.getByText('See More'))
-    expect(screen.queryByTestId('phone')).toBeNull()
-    expect(screen.queryByTestId('address')).toBeNull()
+    expect(screen.getByTestId('no-details')).toBeInTheDocument()
+  })
+
+  it('See More button has no border', () => {
+    render(<PersonalInfoSection />)
+    const btn = screen.getByText('See More')
+    expect(btn.className).not.toMatch(/border/)
   })
 
   it('edit button contains only an icon', () => {

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -13,3 +13,4 @@
 2025-07-11 - Confirmed sliding reveal personal info card for UI-112.
 2025-07-12 - Confirmed card reveal bug fixed and avatar duplicates removed for UI-113.
 2025-07-12 - Confirmed See More tab overlay animation update for UI-114.
+2025-07-12 - Confirmed modal replaces slide reveal for UI-115.

--- a/subagents_report/architectureDiagram.md
+++ b/subagents_report/architectureDiagram.md
@@ -2,3 +2,4 @@ Architecture diagram updated with vendor flow.
 Diagram updated for personal info modal in UI-111.
 Diagram updated for reveal fix in UI-113.
 Diagram updated for sliding tab animation in UI-114.
+Diagram updated for view modal replacement in UI-115.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -13,3 +13,4 @@
 2025-07-11 - No consultations were necessary for UI-112.
 2025-07-12 - No consultations were necessary for UI-113.
 2025-07-12 - No consultations were necessary for UI-114.
+2025-07-12 - No consultations were necessary for UI-115.

--- a/subagents_report/dependencyGraph.md
+++ b/subagents_report/dependencyGraph.md
@@ -2,3 +2,4 @@ Updated dependency graph for FEAT-VEND-MGMT-001 recorded.
 Personal info modal dependencies documented for UI-111.
 Personal info card reveal dependencies updated for UI-113.
 Sliding See More tab animation dependencies updated for UI-114.
+Personal info view modal dependency noted for UI-115.

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -3,3 +3,4 @@ Feedback: Personal info modal flow confirmed.
 Feedback: Please confirm the new personal info sliding card layout for UI-112.
 Feedback: Confirmed layout change with single avatar and reveal fix for UI-113.
 Feedback: Please confirm the new sliding See More tab design for UI-114.
+Feedback: Please confirm the switch to a modal for UI-115.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -13,3 +13,4 @@
 2025-07-11 - Stakeholders informed about new sliding personal info layout for UI-112.
 2025-07-12 - Stakeholders informed about personal info reveal fix for UI-113.
 2025-07-12 - Stakeholders informed about sliding See More tab design for UI-114.
+2025-07-12 - Stakeholders informed about modal replacement of See More for UI-115.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -13,3 +13,4 @@
 2025-07-11 - Redesigned personal info card with slide out details and icon edit button for UI-112.
 2025-07-12 - Fixed personal info reveal and centered details with new tests for UI-113.
 2025-07-12 - Implemented sliding tab overlay animation and updated tests for UI-114.
+2025-07-12 - Replaced sliding reveal with modal and updated tests for UI-115.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -13,3 +13,4 @@
 2025-07-11 - Unit tests updated for sliding reveal and icon button for UI-112.
 2025-07-12 - Tests cover personal info reveal bug fix for UI-113.
 2025-07-12 - Tests verify See More tab toggle and rapid clicks for UI-114.
+2025-07-12 - Tests updated for modal view of personal info for UI-115.


### PR DESCRIPTION
## Summary
- add `PersonalInfoViewModal` component
- simplify `PersonalInfoSection` to open a modal
- update tests for modal behaviour
- document new dependency and architecture
- update milestone and subagent reports

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68720e1593fc832b9aabc7602567cbff