### PR TITLE
UI-116 dark mode personal info card with vendor modal

### DIFF
--- a/Milestones.md
+++ b/Milestones.md
@@ -16,6 +16,7 @@
 - **UI-113** - Fix Personal Info Card Reveal and Remove Duplicate Avatar (status: draft)
 - **UI-114** - Fix and Style See More Reveal Animation (status: draft)
 - **UI-115** - Simplify Personal Info See More into Modal (status: draft)
+- **UI-116** - Dark Mode Personal Info Card with Vendor Button (status: draft)
 
 ## MILESTONE-2 – Core Feature Enhancements
 - **Start:** 2023-10-27

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -28,8 +28,9 @@ note bottom of Main
   PersonalInfoModal updates user_profiles via updateProfile
 end note
 note bottom of Main
-  Personal info card opens a modal to
-  display phone and address when
-  the See More button is clicked
+  Dark themed personal info card shows name and email
+  with Edit and Vendors buttons.
+  The Vendors button opens VendorManagerModal,
+  and See More opens PersonalInfoViewModal.
 end note
 @enduml

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -6,4 +6,6 @@
 - `ProductListingForm` requires vendor selection
 - `PersonalInfoModal` uses `updateProfile` from SupabaseProvider
 - `PersonalInfoViewModal` reads phone and address from SupabaseProvider
+- `PersonalInfoSection` uses dark theme layout with Edit and Vendors buttons
+- `VendorManagerModal` wraps `VendorListManager`
 - `PersonalInfoSection` opens `PersonalInfoViewModal` when See More is clicked

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -9,7 +9,8 @@
 - The product stores the vendor id for participants to reference.
 
 ## Personal Info Modal
-- Shows a single centered avatar with name and email.
-- Edit button (pencil icon) opens the modal to save changes.
-- "See More" opens a simple modal displaying phone and shipping address.
-- If no phone or address is set, the modal says "No additional details".
+- Dark themed card with a green accent bar.
+- Displays the user's name and email next to their avatar.
+- "Edit Personal Info" button opens the edit modal.
+- "Vendors" button opens the vendor manager modal.
+- The green "See More" bar opens a modal showing phone and shipping address or a notice when none exist.

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -4,4 +4,4 @@
 2. Product listing form fetches this list and requires one to be selected.
 3. Selected vendor id is stored with the product so group participants can see supplier details.
 4. PersonalInfoModal allows editing name, phone and address with updates saved on close.
-5. Personal info card shows one centered avatar and email. Tapping "See More" opens a modal that shows phone and address if available.
+5. Personal info card uses a dark theme with green accent. It displays the user's name and email, with buttons for "Edit Personal Info" and "Vendors". A green "See More" bar opens a modal showing phone and address if available.

--- a/src/components/profile/PersonalInfoSection.tsx
+++ b/src/components/profile/PersonalInfoSection.tsx
@@ -1,56 +1,79 @@
 'use client'
 import { useState } from 'react'
 import Image from 'next/image'
-import { Pencil } from 'lucide-react'
+import { Pencil, Users, Zap } from 'lucide-react'
 import { useSupabase } from '@/contexts/SupabaseProvider'
 import { Button } from '@/components/ui/Button'
 import { PersonalInfoModal } from './PersonalInfoModal'
 import { PersonalInfoViewModal } from './PersonalInfoViewModal'
+import { VendorManagerModal } from './VendorManagerModal'
 
 export function PersonalInfoSection() {
   const { profile, session } = useSupabase()
   const [editOpen, setEditOpen] = useState(false)
   const [viewOpen, setViewOpen] = useState(false)
+  const [vendorOpen, setVendorOpen] = useState(false)
 
   const openEditModal = () => setEditOpen(true)
   const closeEditModal = () => setEditOpen(false)
   const openViewModal = () => setViewOpen(true)
   const closeViewModal = () => setViewOpen(false)
+  const openVendorModal = () => setVendorOpen(true)
+  const closeVendorModal = () => setVendorOpen(false)
 
   return (
-    <div className="relative pb-8">
-      <div className="flex flex-col items-center">
-        <div className="relative h-24 w-24 overflow-hidden rounded-full">
-          <Image
-            src={profile?.avatar_url || '/avatars/default.jpg'}
-            alt={profile?.full_name || 'Profile'}
-            fill
-            className="object-cover"
-          />
+    <div className="relative overflow-hidden rounded-xl bg-neutral-900 text-white">
+      <div className="p-4 space-y-4">
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>Personal Information</span>
+          <span>{new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
         </div>
-        <h3 className="mt-2 text-lg font-semibold text-center">
-          {profile?.full_name || 'Not Available'}
-        </h3>
-        <p className="mt-1 text-sm text-muted-foreground text-center">
-          {session?.user.email || ''}
-        </p>
+        <div className="flex items-center gap-3">
+          <div className="relative h-16 w-16 overflow-hidden rounded-full">
+            <Image
+              src={profile?.avatar_url || '/avatars/default.jpg'}
+              alt={profile?.full_name || 'Profile'}
+              fill
+              className="object-cover"
+            />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold">{profile?.full_name || 'Not Available'}</h3>
+            <p className="text-sm text-green-400">{session?.user.email || ''}</p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={openEditModal}
+            aria-label="Edit Personal Information"
+            className="flex-1 flex items-center gap-1"
+          >
+            <Pencil className="h-4 w-4" />
+            Edit Personal Info
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={openVendorModal}
+            className="flex-1 flex items-center gap-1"
+          >
+            <Users className="h-4 w-4" />
+            Vendors
+          </Button>
+        </div>
       </div>
       <button
         onClick={openViewModal}
-        className="absolute left-1/2 bottom-0 translate-y-1/2 -translate-x-1/2 rounded-t-md bg-muted px-3 py-1 text-sm font-medium"
+        className="flex w-full items-center justify-center gap-1 bg-green-500 py-2 text-sm font-medium text-black"
       >
+        <Zap className="h-4 w-4" />
         See More
       </button>
-      <Button
-        size="sm"
-        onClick={openEditModal}
-        aria-label="Edit Personal Information"
-        className="absolute right-2 top-2 p-2"
-      >
-        <Pencil className="h-4 w-4" />
-      </Button>
       <PersonalInfoModal isOpen={editOpen} onClose={closeEditModal} />
       <PersonalInfoViewModal isOpen={viewOpen} onClose={closeViewModal} />
+      <VendorManagerModal isOpen={vendorOpen} onClose={closeVendorModal} />
     </div>
   )
 }

--- a/src/components/profile/VendorManagerModal.tsx
+++ b/src/components/profile/VendorManagerModal.tsx
@@ -1,0 +1,32 @@
+'use client'
+import { X } from 'lucide-react'
+import { VendorListManager } from './VendorListManager'
+
+interface VendorManagerModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function VendorManagerModal({ isOpen, onClose }: VendorManagerModalProps) {
+  if (!isOpen) return null
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-neutral-850 p-6 rounded-lg shadow-xl w-full max-w-sm"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+      >
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold">Vendors</h2>
+          <button onClick={onClose} aria-label="Close" className="text-neutral-500 hover:text-neutral-700">
+            <X size={20} />
+          </button>
+        </div>
+        <VendorListManager />
+      </div>
+    </div>
+  )
+}

--- a/src/components/profile/__tests__/PersonalInfoModal.test.tsx
+++ b/src/components/profile/__tests__/PersonalInfoModal.test.tsx
@@ -3,6 +3,7 @@ import { PersonalInfoSection } from '../PersonalInfoSection'
 
 const mockUpdateProfile = jest.fn()
 const mockUseSupabase = jest.fn()
+global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })) as any
 
 jest.mock('@/contexts/SupabaseProvider', () => ({
   useSupabase: () => mockUseSupabase()
@@ -66,16 +67,16 @@ describe('PersonalInfoSection', () => {
     expect(screen.getByTestId('no-details')).toBeInTheDocument()
   })
 
-  it('See More button has no border', () => {
-    render(<PersonalInfoSection />)
-    const btn = screen.getByText('See More')
-    expect(btn.className).not.toMatch(/border/)
-  })
-
-  it('edit button contains only an icon', () => {
+  it('edit button shows text', () => {
     render(<PersonalInfoSection />)
     const btn = screen.getByLabelText('Edit Personal Information')
-    expect(btn).not.toHaveTextContent(/edit/i)
+    expect(btn).toHaveTextContent(/edit personal info/i)
+  })
+
+  it('opens vendor manager when Vendors clicked', () => {
+    render(<PersonalInfoSection />)
+    fireEvent.click(screen.getByText('Vendors'))
+    expect(screen.getByPlaceholderText('Vendor name')).toBeInTheDocument()
   })
 
   it('saves updates and closes modal', async () => {

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -14,3 +14,4 @@
 2025-07-12 - Confirmed card reveal bug fixed and avatar duplicates removed for UI-113.
 2025-07-12 - Confirmed See More tab overlay animation update for UI-114.
 2025-07-12 - Confirmed modal replaces slide reveal for UI-115.
+2025-07-12 - Updated dark themed personal info card with vendor modal for UI-116.

--- a/subagents_report/architectureDiagram.md
+++ b/subagents_report/architectureDiagram.md
@@ -3,3 +3,4 @@ Diagram updated for personal info modal in UI-111.
 Diagram updated for reveal fix in UI-113.
 Diagram updated for sliding tab animation in UI-114.
 Diagram updated for view modal replacement in UI-115.
+2025-07-12 - Diagram updated with VendorManagerModal for UI-116.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -14,3 +14,4 @@
 2025-07-12 - No consultations were necessary for UI-113.
 2025-07-12 - No consultations were necessary for UI-114.
 2025-07-12 - No consultations were necessary for UI-115.
+2025-07-12 - No consultations were necessary for UI-116.

--- a/subagents_report/dependencyGraph.md
+++ b/subagents_report/dependencyGraph.md
@@ -3,3 +3,4 @@ Personal info modal dependencies documented for UI-111.
 Personal info card reveal dependencies updated for UI-113.
 Sliding See More tab animation dependencies updated for UI-114.
 Personal info view modal dependency noted for UI-115.
+2025-07-12 - Added dark mode personal info card dependencies for UI-116.

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -4,3 +4,4 @@ Feedback: Please confirm the new personal info sliding card layout for UI-112.
 Feedback: Confirmed layout change with single avatar and reveal fix for UI-113.
 Feedback: Please confirm the new sliding See More tab design for UI-114.
 Feedback: Please confirm the switch to a modal for UI-115.
+2025-07-12 | Personal Info Card | Please confirm dark theme redesign with vendor modal.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -14,3 +14,4 @@
 2025-07-12 - Stakeholders informed about personal info reveal fix for UI-113.
 2025-07-12 - Stakeholders informed about sliding See More tab design for UI-114.
 2025-07-12 - Stakeholders informed about modal replacement of See More for UI-115.
+2025-07-12 - Stakeholders informed about new dark mode personal info card with vendor button for UI-116.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -14,3 +14,4 @@
 2025-07-12 - Fixed personal info reveal and centered details with new tests for UI-113.
 2025-07-12 - Implemented sliding tab overlay animation and updated tests for UI-114.
 2025-07-12 - Replaced sliding reveal with modal and updated tests for UI-115.
+2025-07-12 - Implemented VendorManagerModal and updated PersonalInfoSection layout for UI-116.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -14,3 +14,4 @@
 2025-07-12 - Tests cover personal info reveal bug fix for UI-113.
 2025-07-12 - Tests verify See More tab toggle and rapid clicks for UI-114.
 2025-07-12 - Tests updated for modal view of personal info for UI-115.
+2025-07-12 - Updated tests for new personal info card layout for UI-116.


### PR DESCRIPTION
## Summary
- redesign personal info section with dark theme and vendor manager modal
- update tests for new layout
- document new design in functional, feature docs, dependency graph, and architecture diagram
- log updates in subagent reports and add feedback checkpoint
- add milestone entry for UI-116

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68722f037420832ba57ee2b24230fa70