### PR TITLE
UI-117 show name header

### DIFF
--- a/Milestones.md
+++ b/Milestones.md
@@ -17,6 +17,7 @@
 - **UI-114** - Fix and Style See More Reveal Animation (status: draft)
 - **UI-115** - Simplify Personal Info See More into Modal (status: draft)
 - **UI-116** - Dark Mode Personal Info Card with Vendor Button (status: draft)
+- **UI-117** - Show user name in Personal Info header and icon-only edit button (status: draft)
 
 ## MILESTONE-2 – Core Feature Enhancements
 - **Start:** 2023-10-27

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -12,5 +12,7 @@
 - Dark themed card with a green accent bar.
 - Displays the user's name and email next to their avatar.
 - "Edit Personal Info" button opens the edit modal.
+- Edit button shows only a pencil icon with an aria-label.
 - "Vendors" button opens the vendor manager modal.
+- The header above the avatar displays the user's name when available.
 - The green "See More" bar opens a modal showing phone and shipping address or a notice when none exist.

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -4,4 +4,4 @@
 2. Product listing form fetches this list and requires one to be selected.
 3. Selected vendor id is stored with the product so group participants can see supplier details.
 4. PersonalInfoModal allows editing name, phone and address with updates saved on close.
-5. Personal info card uses a dark theme with green accent. It displays the user's name and email, with buttons for "Edit Personal Info" and "Vendors". A green "See More" bar opens a modal showing phone and address if available.
+5. Personal info card uses a dark theme with green accent. The header above the avatar shows the user's name when loaded. The edit button is icon-only with a pencil and accessible aria-label. A green "See More" bar opens a modal showing phone and address if available.

--- a/src/app/profile/__tests__/page.test.tsx
+++ b/src/app/profile/__tests__/page.test.tsx
@@ -142,8 +142,7 @@ describe('ProfilePage', () => {
      const PageComponent = await ProfilePage();
      render(PageComponent);
 
-     expect(screen.getByText('Personal Information')).toBeInTheDocument();
-     expect(screen.getByDisplayValue('Test User')).toBeInTheDocument();
+     expect(screen.getAllByText('Test User').length).toBeGreaterThan(0);
      expect(screen.getByDisplayValue('test@example.com')).toBeInTheDocument();
      expect(redirect).not.toHaveBeenCalled();
   });

--- a/src/components/profile/PersonalInfoSection.tsx
+++ b/src/components/profile/PersonalInfoSection.tsx
@@ -25,7 +25,7 @@ export function PersonalInfoSection() {
     <div className="relative overflow-hidden rounded-xl bg-neutral-900 text-white">
       <div className="p-4 space-y-4">
         <div className="flex justify-between text-xs text-muted-foreground">
-          <span>Personal Information</span>
+          <span>{profile?.full_name || 'Personal Information'}</span>
           <span>{new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
         </div>
         <div className="flex items-center gap-3">
@@ -48,10 +48,9 @@ export function PersonalInfoSection() {
             variant="secondary"
             onClick={openEditModal}
             aria-label="Edit Personal Information"
-            className="flex-1 flex items-center gap-1"
+            className="flex-1 flex items-center justify-center"
           >
             <Pencil className="h-4 w-4" />
-            Edit Personal Info
           </Button>
           <Button
             size="sm"

--- a/src/components/profile/__tests__/PersonalInfoModal.test.tsx
+++ b/src/components/profile/__tests__/PersonalInfoModal.test.tsx
@@ -67,10 +67,11 @@ describe('PersonalInfoSection', () => {
     expect(screen.getByTestId('no-details')).toBeInTheDocument()
   })
 
-  it('edit button shows text', () => {
+  it('edit button is icon only', () => {
     render(<PersonalInfoSection />)
     const btn = screen.getByLabelText('Edit Personal Information')
-    expect(btn).toHaveTextContent(/edit personal info/i)
+    expect(btn).not.toHaveTextContent(/edit personal info/i)
+    expect(btn.querySelector('svg')).toBeInTheDocument()
   })
 
   it('opens vendor manager when Vendors clicked', () => {

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -16,3 +16,4 @@
 2025-07-12 - Confirmed modal replaces slide reveal for UI-115.
 2025-07-12 - Updated dark themed personal info card with vendor modal for UI-116.
 2025-07-13 - Resolved ESLint build error for CFG-001.
+2025-07-14 - Confirmed user name header and icon-only edit button for UI-117.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -16,3 +16,4 @@
 2025-07-12 - No consultations were necessary for UI-115.
 2025-07-12 - No consultations were necessary for UI-116.
 2025-07-13 - No consultations were required for CFG-001.
+2025-07-14 - No consultations were necessary for UI-117.

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -6,3 +6,4 @@ Feedback: Please confirm the new sliding See More tab design for UI-114.
 Feedback: Please confirm the switch to a modal for UI-115.
 2025-07-12 | Personal Info Card | Please confirm dark theme redesign with vendor modal.
 2025-07-13 | ESLint Fix | Please confirm accessibility changes resolve deployment error.
+2025-07-14 | Personal Info Header | Please confirm user name replaces label and edit button has only icon for UI-117.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -16,3 +16,4 @@
 2025-07-12 - Stakeholders informed about modal replacement of See More for UI-115.
 2025-07-12 - Stakeholders informed about new dark mode personal info card with vendor button for UI-116.
 2025-07-13 - Stakeholders informed about lint fix deployment.
+2025-07-14 - Stakeholders informed about new personal info header and edit icon for UI-117.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -16,3 +16,4 @@
 2025-07-12 - Replaced sliding reveal with modal and updated tests for UI-115.
 2025-07-12 - Implemented VendorManagerModal and updated PersonalInfoSection layout for UI-116.
 2025-07-13 - Fixed deployment lint errors.
+2025-07-14 - Updated header and edit button for UI-117 with passing tests.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -16,3 +16,4 @@
 2025-07-12 - Tests updated for modal view of personal info for UI-115.
 2025-07-12 - Updated tests for new personal info card layout for UI-116.
 2025-07-13 - Lint and tests pass for CFG-001.
+2025-07-14 - Unit tests updated for UI-117.


### PR DESCRIPTION
## Summary
- replace personal info header with user name
- switch edit button to icon-only
- update personal info tests
- adjust profile page test
- document milestone and RACI updates

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68723c82cefc832b94836b728439edcf