### PR TITLE
UI-119 Personal Info label

### DIFF
--- a/Milestones.md
+++ b/Milestones.md
@@ -19,6 +19,7 @@
 - **UI-116** - Dark Mode Personal Info Card with Vendor Button (status: draft)
 - **UI-117** - Show user name in Personal Info header and icon-only edit button (status: draft)
 - **UI-118** - Merge Personal Info card and remove duplicate text (status: draft)
+- **UI-119** - Add Personal Info label with icon on profile card (status: draft)
 
 ## MILESTONE-2 – Core Feature Enhancements
 - **Start:** 2023-10-27

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -14,6 +14,6 @@
 - "Edit Personal Info" button opens the edit modal.
 - Edit button shows only a pencil icon with an aria-label.
 - "Vendors" button opens the vendor manager modal.
-- The header above the avatar displays the user's name when available.
+- The header now displays a "Personal Info" label with a user icon while the user's name and email remain next to the avatar.
 - The green "See More" bar opens a modal showing phone and shipping address or a notice when none exist.
 - On the profile page, this personal info card now appears directly without an extra wrapper and no duplicate heading text.

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -4,5 +4,5 @@
 2. Product listing form fetches this list and requires one to be selected.
 3. Selected vendor id is stored with the product so group participants can see supplier details.
 4. PersonalInfoModal allows editing name, phone and address with updates saved on close.
-5. Personal info card uses a dark theme with green accent. The header above the avatar shows the user's name when loaded. The edit button is icon-only with a pencil and accessible aria-label. A green "See More" bar opens a modal showing phone and address if available.
+5. Personal info card uses a dark theme with green accent. The header displays a "Personal Info" label with a user icon while the user's name appears beside their avatar. The edit button is icon-only with a pencil and accessible aria-label. A green "See More" bar opens a modal showing phone and address if available.
 6. Profile page embeds this personal info card directly without an outer wrapper to avoid duplicate headings.

--- a/src/components/profile/PersonalInfoSection.tsx
+++ b/src/components/profile/PersonalInfoSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { useState } from 'react'
 import Image from 'next/image'
-import { Pencil, Users, Zap } from 'lucide-react'
+import { Pencil, Users, Zap, User } from 'lucide-react'
 import { useSupabase } from '@/contexts/SupabaseProvider'
 import { Button } from '@/components/ui/Button'
 import { PersonalInfoModal } from './PersonalInfoModal'
@@ -21,12 +21,22 @@ export function PersonalInfoSection() {
   const openVendorModal = () => setVendorOpen(true)
   const closeVendorModal = () => setVendorOpen(false)
 
+  let timeString = ''
+  try {
+    timeString = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  } catch {
+    timeString = ''
+  }
+
   return (
     <div className="relative overflow-hidden rounded-xl bg-neutral-900 text-white">
       <div className="p-4 space-y-4">
         <div className="flex justify-between text-xs text-muted-foreground">
-          <span>{profile?.full_name || ''}</span>
-          <span>{new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+          <span className="flex items-center gap-1">
+            <User className="h-3.5 w-3.5" />
+            Personal Info
+          </span>
+          <span>{timeString}</span>
         </div>
         <div className="flex items-center gap-3">
           <div className="relative h-16 w-16 overflow-hidden rounded-full">

--- a/src/components/profile/__tests__/PersonalInfoModal.test.tsx
+++ b/src/components/profile/__tests__/PersonalInfoModal.test.tsx
@@ -31,6 +31,11 @@ describe('PersonalInfoSection', () => {
     expect(screen.queryByRole('dialog')).toBeNull()
   })
 
+  it('shows personal info label with icon', () => {
+    render(<PersonalInfoSection />)
+    expect(screen.getByText('Personal Info')).toBeInTheDocument()
+  })
+
   it('opens modal with details when See More clicked', () => {
     render(<PersonalInfoSection />)
     fireEvent.click(screen.getByText('See More'))

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -18,3 +18,4 @@
 2025-07-13 - Resolved ESLint build error for CFG-001.
 2025-07-14 - Confirmed user name header and icon-only edit button for UI-117.
 2025-07-15 - Confirmed outer card replaced by inner design for UI-118.
+2025-07-16 - Confirmed Personal Info label with icon for UI-119.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -18,3 +18,4 @@
 2025-07-13 - No consultations were required for CFG-001.
 2025-07-14 - No consultations were necessary for UI-117.
 2025-07-15 - No consultations were necessary for UI-118.
+2025-07-16 - No consultations were necessary for UI-119.

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -8,3 +8,4 @@ Feedback: Please confirm the switch to a modal for UI-115.
 2025-07-13 | ESLint Fix | Please confirm accessibility changes resolve deployment error.
 2025-07-14 | Personal Info Header | Please confirm user name replaces label and edit button has only icon for UI-117.
 2025-07-15 | Personal Info Card | Please confirm outer card replaced by inner design and duplicate text removed for UI-118.
+2025-07-16 | Personal Info Label | Please confirm new label with user icon at top-left of card for UI-119.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -18,3 +18,4 @@
 2025-07-13 - Stakeholders informed about lint fix deployment.
 2025-07-14 - Stakeholders informed about new personal info header and edit icon for UI-117.
 2025-07-15 - Stakeholders informed about merged personal info card for UI-118.
+2025-07-16 - Stakeholders informed about Personal Info label with icon for UI-119.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -18,3 +18,4 @@
 2025-07-13 - Fixed deployment lint errors.
 2025-07-14 - Updated header and edit button for UI-117 with passing tests.
 2025-07-15 - Merged inner card layout into profile page and removed duplicate text for UI-118.
+2025-07-16 - Added Personal Info label with icon and updated tests for UI-119.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -18,3 +18,4 @@
 2025-07-13 - Lint and tests pass for CFG-001.
 2025-07-14 - Unit tests updated for UI-117.
 2025-07-15 - Updated tests to verify personal info card renders without wrapper for UI-118.
+2025-07-16 - Added unit test for Personal Info label rendering for UI-119.


### PR DESCRIPTION
## Summary
- add a `Personal Info` label with a User icon
- keep the name next to the avatar
- test rendering of the new label
- document the header change
- log the task in milestone and subagent reports

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68725603c41c832bb99fee64f021794c