### PR TITLE
UI-121 avatar badge fix

### DIFF
--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -31,6 +31,10 @@ note bottom of Main
   AvatarEditModal updates avatar_url via updateProfile
 end note
 note bottom of Main
+  Avatar badge positioned outside thumbnail
+  opens AvatarEditModal and refreshes avatar
+end note
+note bottom of Main
   Dark themed personal info card shows name and email
   with Edit and Vendors buttons.
   The Vendors button opens VendorManagerModal,

--- a/docs/dependency-graph.md
+++ b/docs/dependency-graph.md
@@ -11,3 +11,5 @@
 - `PersonalInfoSection` opens `PersonalInfoViewModal` when See More is clicked
 - `ProfilePage` embeds `PersonalInfoSection` directly without a surrounding `Card`
 - `AvatarEditModal` updates `user_profiles.avatar_url` via `updateProfile`
+- Avatar badge outside thumbnail opens `AvatarEditModal` and refreshed avatar
+- Next.js image config permits remote avatar URLs

--- a/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
+++ b/feature-by-feature-documentation(Non-Technical, Stakeholder-Friendly, Updated for Auto-Supplier Role on Product Listing).md
@@ -16,5 +16,5 @@
 - "Vendors" button opens the vendor manager modal.
 - The header now displays a "Personal Info" label with a user icon while the user's name and email remain next to the avatar.
 - The green "See More" bar opens a modal showing phone and shipping address or a notice when none exist.
-- On the profile page, this personal info card now appears directly without an extra wrapper and no duplicate heading text.
-- A small badge on the avatar opens an edit modal allowing the user to paste an image URL to update their picture.
+ - On the profile page, this personal info card now appears directly without an extra wrapper and no duplicate heading text.
+ - A small badge sits slightly outside the avatar thumbnail. Clicking it opens an edit modal for pasting an image URL. The input text is dark in light mode and white in dark mode, and the avatar preview refreshes after saving.

--- a/functional_representation.md
+++ b/functional_representation.md
@@ -7,3 +7,5 @@
 5. Personal info card uses a dark theme with green accent. The header displays a "Personal Info" label with a user icon while the user's name appears beside their avatar. The edit button is icon-only with a pencil and accessible aria-label. A green "See More" bar opens a modal showing phone and address if available.
 6. Profile page embeds this personal info card directly without an outer wrapper to avoid duplicate headings.
 7. Users can update their profile picture through an avatar edit modal that accepts an image URL.
+8. An edit badge sits slightly outside the avatar thumbnail and opens the modal.
+9. The avatar refreshes after saving a new URL and the input text remains visible in both themes.

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,10 @@ const nextConfig = {
   output: 'standalone',
   images: {
     domains: ['via.placeholder.com', 'placehold.co'],
+    remotePatterns: [
+      { protocol: 'https', hostname: '**' },
+      { protocol: 'http', hostname: '**' },
+    ],
   },
   webpack: (config) => {
     config.resolve.alias['@'] = path.join(__dirname, 'src');

--- a/src/components/profile/AvatarEditModal.tsx
+++ b/src/components/profile/AvatarEditModal.tsx
@@ -67,7 +67,7 @@ export function AvatarEditModal({ isOpen, onClose }: AvatarEditModalProps) {
             placeholder="Image URL"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
-            className="w-full border rounded px-2 py-1"
+            className="w-full border rounded px-2 py-1 text-neutral-900 dark:text-white"
           />
           {error && <p className="text-red-500 text-sm">{error}</p>}
           <div className="flex gap-2 pt-1">

--- a/src/components/profile/PersonalInfoSection.tsx
+++ b/src/components/profile/PersonalInfoSection.tsx
@@ -43,17 +43,19 @@ export function PersonalInfoSection() {
           <span>{timeString}</span>
         </div>
         <div className="flex items-center gap-3">
-          <div className="relative h-16 w-16 overflow-hidden rounded-full">
-            <Image
-              src={profile?.avatar_url || '/avatars/default.jpg'}
-              alt={profile?.full_name || 'Profile'}
-              fill
-              className="object-cover"
-            />
+          <div className="relative">
+            <div className="relative h-16 w-16 overflow-hidden rounded-full">
+              <Image
+                src={profile?.avatar_url || '/avatars/default.jpg'}
+                alt={profile?.full_name || 'Profile'}
+                fill
+                className="object-cover"
+              />
+            </div>
             <button
               onClick={openAvatarModal}
               aria-label="Edit Avatar"
-              className="absolute bottom-0 right-0 flex h-5 w-5 items-center justify-center rounded-full bg-neutral-800 text-white"
+              className="absolute -bottom-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full bg-neutral-800 text-white"
             >
               <Pencil className="h-3 w-3" />
             </button>

--- a/src/components/profile/__tests__/PersonalInfoModal.test.tsx
+++ b/src/components/profile/__tests__/PersonalInfoModal.test.tsx
@@ -85,6 +85,32 @@ describe('PersonalInfoSection', () => {
     expect(screen.getByPlaceholderText('Vendor name')).toBeInTheDocument()
   })
 
+  it('opens avatar edit modal when badge clicked', () => {
+    render(<PersonalInfoSection />)
+    fireEvent.click(screen.getByLabelText('Edit Avatar'))
+    expect(screen.getByPlaceholderText('Image URL')).toBeInTheDocument()
+  })
+
+  it('refreshes avatar when profile url changes', () => {
+    const profile = {
+      full_name: 'Test User',
+      avatar_url: '/old.jpg',
+      phone_number: '123',
+      shipping_address: '123 Street',
+    }
+    mockUseSupabase.mockReturnValue({
+      profile,
+      session: { user: { email: 'test@example.com' } },
+      updateProfile: jest.fn((updates) => Object.assign(profile, updates)),
+    })
+    const { rerender } = render(<PersonalInfoSection />)
+    const img = screen.getByAltText('Test User') as HTMLImageElement
+    expect(img.src).toContain('%2Fold.jpg')
+    profile.avatar_url = '/new.jpg'
+    rerender(<PersonalInfoSection />)
+    expect(screen.getByAltText('Test User').getAttribute('src')).toContain('%2Fnew.jpg')
+  })
+
   it('saves updates and closes modal', async () => {
     render(<PersonalInfoSection />)
     fireEvent.click(screen.getByLabelText('Edit Personal Information'))

--- a/subagents_report/accountable.md
+++ b/subagents_report/accountable.md
@@ -20,3 +20,4 @@
 2025-07-15 - Confirmed outer card replaced by inner design for UI-118.
 2025-07-16 - Confirmed Personal Info label with icon for UI-119.
 2025-07-17 - Confirmed avatar edit modal for UI-120.
+2025-07-17 - Confirmed avatar badge positioning and input visibility for UI-121.

--- a/subagents_report/architectureDiagram.md
+++ b/subagents_report/architectureDiagram.md
@@ -7,3 +7,4 @@ Diagram updated for view modal replacement in UI-115.
 2025-07-13 - Architecture unaffected.
 2025-07-15 - Architecture unchanged aside from removing nested personal info card for UI-118.
 2025-07-17 - Diagram updated with AvatarEditModal for UI-120.
+2025-07-17 - Diagram updated with avatar badge outside thumbnail for UI-121.

--- a/subagents_report/consulted.md
+++ b/subagents_report/consulted.md
@@ -20,3 +20,4 @@
 2025-07-15 - No consultations were necessary for UI-118.
 2025-07-16 - No consultations were necessary for UI-119.
 2025-07-17 - No consultations were necessary for UI-120.
+2025-07-17 - No consultations were necessary for UI-121.

--- a/subagents_report/dbSchemaBackup.md
+++ b/subagents_report/dbSchemaBackup.md
@@ -2,3 +2,4 @@ New user_managed_vendors table and products.selected_user_vendor_id column added
 2025-07-13 - No DB schema changes.
 2025-07-15 - No DB schema changes.
 2025-07-17 - No DB schema changes for UI-120.
+2025-07-17 - No DB schema changes for UI-121.

--- a/subagents_report/dependencyGraph.md
+++ b/subagents_report/dependencyGraph.md
@@ -7,3 +7,4 @@ Personal info view modal dependency noted for UI-115.
 2025-07-13 - No dependency graph changes for CFG-001.
 2025-07-15 - Removed outer card dependency; profile uses PersonalInfoSection directly for UI-118.
 2025-07-17 - Added AvatarEditModal dependency for UI-120.
+2025-07-17 - Updated dependency graph for avatar badge positioning for UI-121.

--- a/subagents_report/feedback.md
+++ b/subagents_report/feedback.md
@@ -10,3 +10,4 @@ Feedback: Please confirm the switch to a modal for UI-115.
 2025-07-15 | Personal Info Card | Please confirm outer card replaced by inner design and duplicate text removed for UI-118.
 2025-07-16 | Personal Info Label | Please confirm new label with user icon at top-left of card for UI-119.
 2025-07-17 | Avatar Edit | Please confirm avatar URL modal for UI-120.
+2025-07-17 | Avatar Badge | Please confirm new badge position, input contrast and preview refresh for UI-121.

--- a/subagents_report/informed.md
+++ b/subagents_report/informed.md
@@ -20,3 +20,4 @@
 2025-07-15 - Stakeholders informed about merged personal info card for UI-118.
 2025-07-16 - Stakeholders informed about Personal Info label with icon for UI-119.
 2025-07-17 - Stakeholders informed about avatar URL edit feature for UI-120.
+2025-07-17 - Stakeholders informed about new avatar badge position and refresh for UI-121.

--- a/subagents_report/responsible.md
+++ b/subagents_report/responsible.md
@@ -20,3 +20,4 @@
 2025-07-15 - Merged inner card layout into profile page and removed duplicate text for UI-118.
 2025-07-16 - Added Personal Info label with icon and updated tests for UI-119.
 2025-07-17 - Added AvatarEditModal with tests for UI-120.
+2025-07-17 - Positioned avatar edit badge outside thumbnail and ensured avatar refresh for UI-121.

--- a/subagents_report/unit.md
+++ b/subagents_report/unit.md
@@ -20,3 +20,4 @@
 2025-07-15 - Updated tests to verify personal info card renders without wrapper for UI-118.
 2025-07-16 - Added unit test for Personal Info label rendering for UI-119.
 2025-07-17 - Added tests for AvatarEditModal open/close and update for UI-120.
+2025-07-17 - Added tests for avatar badge click and profile refresh for UI-121.


### PR DESCRIPTION
## Summary
- move avatar badge outside thumbnail
- keep text readable in the avatar edit modal
- allow remote avatar URLs in image config
- refresh avatar in PersonalInfoSection on profile update
- document updated dependency graph and architecture
- update subagent reports
- test avatar badge click and avatar refresh

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687411ef6f24832b80200c7709444631